### PR TITLE
Fix service import

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prebuild": "gulp build",
     "build": "node_modules/.bin/electron-builder --publish onTag",
     "rebuild": "node_modules/.bin/electron-rebuild",
+    "precommit": "yarn lint",
     "commit": "git-cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },

--- a/src/components/auth/Import.js
+++ b/src/components/auth/Import.js
@@ -99,7 +99,6 @@ export default class Import extends Component {
                   <tr
                     key={service.id}
                     className="service-table__row"
-                    onClick={() => service.$('add').set(!service.$('add').value)}
                   >
                     <td className="service-table__toggle">
                       <Toggle

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -192,6 +192,15 @@ export default class UserStore extends Store {
   @action async _importLegacyServices({ services }) {
     this.isImportLegacyServicesExecuting = true;
 
+    // Reduces recipe duplicates
+    const recipes = services.filter((obj, pos, arr) => arr.map(mapObj => mapObj.recipe.id).indexOf(obj.recipe.id) === pos).map(s => s.recipe.id);
+
+    // Install recipes
+    for (const recipe of recipes) {
+      // eslint-disable-next-line
+      await this.stores.recipes._install({ recipeId: recipe });
+    }
+
     for (const service of services) {
       this.actions.service.createFromLegacyService({
         data: service,


### PR DESCRIPTION
This PR is fixing the service import when signing up for Franz

### How Has This Been Tested?
- Cleared `~/Library/Application Support/Franz/recipes`
- Sign up for a new Franz account
- Select the services you'd like to import
- Checked `~/Library/Application Support/Franz/recipes` if all recipes have been installed
- Checked in _Added Services_ if services have been added

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).