### PR TITLE
Rename "Taskleiste" to "Systemleiste", Fix #138

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -126,7 +126,7 @@
   "settings.app.updateStatusUpToDate": "Du nutzt die aktuellste Version von Franz",
   "settings.app.form.autoLaunchOnStart": "Franz beim Systemstart ausführen",
   "settings.app.form.autoLaunchInBackground": "Im Hintergrund öffnen",
-  "settings.app.form.minimizeToSystemTray": "Franz in die Taskleiste minimieren",
+  "settings.app.form.minimizeToSystemTray": "Franz in die Systemleiste minimieren",
   "settings.app.form.runInBackground": "Franz im Hintergrund behalten, wenn das Fenster geschlossen wird",
   "settings.app.form.language": "Sprache",
   "settings.app.form.beta": "Beta-Versionen einbeziehen",


### PR DESCRIPTION
Fix #138 by renaming "Taskleiste" to "Systemleiste".

Thos should be more understandable