### PR TITLE
Reset status when navigating away from services screen

### DIFF
--- a/src/actions/service.js
+++ b/src/actions/service.js
@@ -63,6 +63,7 @@ export default {
     needle: PropTypes.string.isRequired,
   },
   resetFilter: {},
+  resetStatus: {},
   reorder: {
     oldIndex: PropTypes.number.isRequired,
     newIndex: PropTypes.number.isRequired,

--- a/src/containers/settings/ServicesScreen.js
+++ b/src/containers/settings/ServicesScreen.js
@@ -18,6 +18,7 @@ export default class ServicesScreen extends Component {
 
   componentWillUnmount() {
     this.props.actions.service.resetFilter();
+    this.props.actions.service.resetStatus();
   }
 
   deleteService() {
@@ -70,6 +71,7 @@ ServicesScreen.wrappedComponent.propTypes = {
       toggleService: PropTypes.func.isRequired,
       filter: PropTypes.func.isRequired,
       resetFilter: PropTypes.func.isRequired,
+      resetStatus: PropTypes.func.isRequired,
     }).isRequired,
   }).isRequired,
 };

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -41,6 +41,7 @@ export default class ServicesStore extends Store {
     this.actions.service.openWindow.listen(this._openWindow.bind(this));
     this.actions.service.filter.listen(this._filter.bind(this));
     this.actions.service.resetFilter.listen(this._resetFilter.bind(this));
+    this.actions.service.resetStatus.listen(this._resetStatus.bind(this));
     this.actions.service.reload.listen(this._reload.bind(this));
     this.actions.service.reloadActive.listen(this._reloadActive.bind(this));
     this.actions.service.reloadAll.listen(this._reloadAll.bind(this));
@@ -336,6 +337,10 @@ export default class ServicesStore extends Store {
 
   @action _resetFilter() {
     this.filterNeedle = null;
+  }
+
+  @action _resetStatus() {
+    this.actionStatus = [];
   }
 
   @action _reload({ serviceId }) {


### PR DESCRIPTION
After navigating away from the services tab in settings, the infobox should go away.

### Description
Reset the `actionStatus` of the service store when the service dashboard is unmounted.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Alleviates confusion when a user is navigating through the settings and sees old service changes in the infobox.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on OS X High Sierra

### Screenshots (if appropriate):
The below still shows when navigating back to the service tab after clicking on a different tab.
<img width="634" alt="screen shot 2017-10-29 at 7 00 38 pm" src="https://user-images.githubusercontent.com/1170755/32149470-7ad80daa-bcdb-11e7-9251-76548e8fd026.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)