### PR TITLE
Added plugin form to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!--- Provide a general summary of the issue in the Title above -->
 
+<!-- This repository is only for the Franz client. Please use this form ( https://adlk.typeform.com/to/Bj7vGq ) for service requests or check out the guide ( https://github.com/meetfranz/plugins ) to create your own service integration. -->
+
 <!--- If you want to propose a feature, use this template: https://raw.githubusercontent.com/meetfranz/franz/master/.github/FEATURE_PROPOSAL_TEMPLATE.md -->
 
 ### Expected Behavior


### PR DESCRIPTION
Hey @adlk ,

I thought it would be beneficial to add to the `ISSUE_TEMPLATE.md` file the usual reply you give to people when they ask for a new recipe through a GitHub issue instead of the form.

That ideally would reduce the number of people doing that!