### PR TITLE
Prevent app from redirecting when dropping link

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -101,3 +101,7 @@ window.addEventListener('load', () => {
   };
   window.franz.render();
 });
+
+// Prevent drag and drop into window from redirecting
+window.addEventListener('dragover', event => event.preventDefault());
+window.addEventListener('drop', event => event.preventDefault());


### PR DESCRIPTION
Fixes #219 

### Description
Disables the `dragover` and `drag` events

### Motivation and Context
Better usability when accidentally dragging into the Franz sidebar

### How Has This Been Tested?
Tested on OSX 10.13

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).