### PR TITLE
[PR - WIP] Change tabs with mousewheel / scroll

### DIFF
--- a/src/components/services/tabs/TabBarSortableList.js
+++ b/src/components/services/tabs/TabBarSortableList.js
@@ -19,6 +19,8 @@ class TabBarSortableList extends Component {
   static propTypes = {
     services: MobxPropTypes.arrayOrObservableArray.isRequired,
     setActive: PropTypes.func.isRequired,
+    setActiveNext: PropTypes.func.isRequired,
+    setActivePrev: PropTypes.func.isRequired,
     openSettings: PropTypes.func.isRequired,
     reload: PropTypes.func.isRequired,
     toggleNotifications: PropTypes.func.isRequired,
@@ -34,6 +36,8 @@ class TabBarSortableList extends Component {
     const {
       services,
       setActive,
+      setActiveNext,
+      setActivePrev,
       reload,
       toggleNotifications,
       deleteService,
@@ -46,6 +50,7 @@ class TabBarSortableList extends Component {
     return (
       <ul
         className="tabs"
+        onWheel={e => (e.deltaY > 0 ? setActiveNext() : setActivePrev())}
       >
         {services.map((service, index) => (
           <TabItem

--- a/src/components/services/tabs/Tabbar.js
+++ b/src/components/services/tabs/Tabbar.js
@@ -9,6 +9,8 @@ export default class TabBar extends Component {
   static propTypes = {
     services: MobxPropTypes.arrayOrObservableArray.isRequired,
     setActive: PropTypes.func.isRequired,
+    setActiveNext: PropTypes.func.isRequired,
+    setActivePrev: PropTypes.func.isRequired,
     openSettings: PropTypes.func.isRequired,
     enableToolTip: PropTypes.func.isRequired,
     disableToolTip: PropTypes.func.isRequired,
@@ -47,6 +49,8 @@ export default class TabBar extends Component {
     const {
       services,
       setActive,
+      setActiveNext,
+      setActivePrev,
       openSettings,
       disableToolTip,
       reload,
@@ -59,6 +63,8 @@ export default class TabBar extends Component {
         <TabBarSortableList
           services={services}
           setActive={setActive}
+          setActiveNext={setActiveNext}
+          setActivePrev={setActivePrev}
           onSortEnd={this.onSortEnd}
           onSortStart={disableToolTip}
           reload={reload}

--- a/src/containers/layout/AppLayoutContainer.js
+++ b/src/containers/layout/AppLayoutContainer.js
@@ -36,6 +36,8 @@ export default class AppLayoutContainer extends Component {
 
     const {
       setActive,
+      setActiveNext,
+      setActivePrev,
       handleIPCMessage,
       setWebviewReference,
       openWindow,
@@ -79,6 +81,8 @@ export default class AppLayoutContainer extends Component {
       <Sidebar
         services={allServices}
         setActive={setActive}
+        setActiveNext={setActiveNext}
+        setActivePrev={setActivePrev}
         openSettings={openSettings}
         closeSettings={closeSettings}
         reorder={reorder}
@@ -137,6 +141,8 @@ AppLayoutContainer.wrappedComponent.propTypes = {
   actions: PropTypes.shape({
     service: PropTypes.shape({
       setActive: PropTypes.func.isRequired,
+      setActiveNext: PropTypes.func.isRequired,
+      setActivePrev: PropTypes.func.isRequired,
       reload: PropTypes.func.isRequired,
       toggleNotifications: PropTypes.func.isRequired,
       handleIPCMessage: PropTypes.func.isRequired,


### PR DESCRIPTION
Allows users to change to the next tab/service using the mouse wheel.
Scrolling down changes to the next tab. Scrolling up changes to the previous tab.
Consistent with the behavior of many applications, such as Chrome, Atom, and Sublime Text.

### Description
Adds an `onWheel` event to `TabBarSortableList.js` that fires `setActiveNext` and `setActivePrev` depending on scroll direction. `setActiveNext` and `setActivePrev` are now passed down through the component prop tree in the same way as `setActive` in order to reach the `TabBarSortableList` component.

### Motivation and Context
My primary method of changing tabs in most applications tends to be by scrolling on the tab bar. It allows for rapidly switching between two or more nearby tabs without needing to click them with any accuracy or use the keyboard.

### How Has This Been Tested?
**Testing Procedures**
- Start Franz with the development instructions listed in the readme.
- Log in and add more than one service.
- Scroll anywhere on the tabbar except the settings button in order to change tabs.

**Environment**
- Linux x64 (Arch)
- X11 Display Server

### Screenshots (if appropriate):
![peek 2017-11-07 13-41](https://user-images.githubusercontent.com/5861371/32478772-30a1dae6-c34c-11e7-9d91-656817e303a6.gif)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
