### PR TITLE
Fix setting notification onNotify

### DIFF
--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -66,7 +66,7 @@ class RecipeWebview {
 
   onNotify(fn) {
     if (typeof fn === 'function') {
-      window.Notification.onNotify = fn;
+      window.Notification.prototype.onNotify = fn;
     }
   }
 

--- a/src/webview/notifications.js
+++ b/src/webview/notifications.js
@@ -10,9 +10,9 @@ class Notification {
     this.notificationId = uuidV1();
 
     ipcRenderer.sendToHost('notification', this.onNotify({
+      title: this.title,
+      options: this.options,
       notificationId: this.notificationId,
-      title,
-      options,
     }));
 
     ipcRenderer.once(`notification-onclick:${this.notificationId}`, () => {


### PR DESCRIPTION
`onNotify` was not being called because of scoping

### Description
Bug was introduced in 9593b28a7b2c3aa4adb6ccca5d4d2d5bf0b95017. `Notification.onNotify` contains the recipe `onNotify`, but `this.onNotify` is currently called in the franz web view. Changed to modifying `Notification.prototype.onNotify`.

### Motivation and Context
Addresses a bug that results in `onNotify` for messenger not being called.

### How Has This Been Tested?
Tested on OSX High Sierra

### Screenshots (if appropriate):

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
