### PR TITLE
[PR] Fix tabs reordering

### DIFF
--- a/src/components/services/tabs/Tabbar.js
+++ b/src/components/services/tabs/Tabbar.js
@@ -30,6 +30,8 @@ export default class TabBar extends Component {
     reorder({ oldIndex, newIndex });
   };
 
+  shouldPreventSorting = event => event.target.tagName !== 'LI';
+
   toggleService = ({ serviceId, isEnabled }) => {
     const { updateService } = this.props;
 
@@ -71,6 +73,7 @@ export default class TabBar extends Component {
           setActive={setActive}
           onSortEnd={this.onSortEnd}
           onSortStart={disableToolTip}
+          shouldCancelStart={this.shouldPreventSorting}
           reload={reload}
           toggleNotifications={toggleNotifications}
           toggleAudio={toggleAudio}

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -470,8 +470,10 @@ export default class ServicesStore extends Store {
     const service = this.active;
 
     if (service) {
-      this.stores.settings.updateSettingsRequest.execute({
-        activeService: service.id,
+      this.actions.settings.update({
+        settings: {
+          activeService: service.id,
+        },
       });
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is my very first open source contribution 😄 

### Description
These changes fix two issues related to service tab reordering in the tab bar.
1. Service tabs can be dragged when clicking in the sidebar background
2. After reordering tabs, the previously active tab becomes the current active tab

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #283 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in Windows 10 using development mode (`npm run dev`) and final build (`npm run build`).
Compared sidebar behaviour to current `develop` branch  to ensure no side effects are introduced.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
