### PR TITLE
Do not strip www from custom urls

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--- Provide a general summary of the issue in the Title above -->
 
-<!-- This repository is only for the Franz client. Please use this form ( https://adlk.typeform.com/to/Bj7vGq ) for service requests or check out the guide ( https://github.com/meetfranz/plugins ) to create your own service integration. -->
+<!-- This repository is only for the Franz client. Please use this form ( https://goo.gl/forms/zbwlx3VFvAo2oink2q ) for service requests or check out the guide ( https://github.com/meetfranz/plugins ) to create your own service integration. -->
 
 <!--- If you want to propose a feature, use this template: https://raw.githubusercontent.com/meetfranz/franz/master/.github/FEATURE_PROPOSAL_TEMPLATE.md -->
 

--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -110,7 +110,7 @@ export default class EditServiceForm extends Component {
         if (recipe.validateUrl && values.customUrl) {
           this.setState({ isValidatingCustomUrl: true });
           try {
-            values.customUrl = normalizeUrl(values.customUrl);
+            values.customUrl = normalizeUrl(values.customUrl, { stripWWW: false });
             isValid = await recipe.validateUrl(values.customUrl);
           } catch (err) {
             console.warn('ValidateURL', err);

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -60,7 +60,7 @@ export default class Service {
     if (this.recipe.hasCustomUrl && this.customUrl) {
       let url;
       try {
-        url = normalizeUrl(this.customUrl);
+        url = normalizeUrl(this.customUrl, { stripWWW: false });
       } catch (err) {
         console.error(`Service (${this.recipe.name}): '${this.customUrl}' is not a valid Url.`);
       }


### PR DESCRIPTION
Stripping www from the custom url causes some custom services to fail.
When there is no domain without www loading is not possible.

Resolves: #325