### PR TITLE
Fix service keyboard shortcut numbering

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -249,7 +249,7 @@ export default class FranzMenu {
   }
 
   @computed get serviceTpl() {
-    const services = this.stores.services.enabled;
+    const services = this.stores.services.allDisplayed;
 
     if (this.stores.user.isLoggedIn) {
       return services.map((service, i) => ({

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -138,7 +138,7 @@ export default class AppStore extends Store {
         this.actions.service.setActivePrev();
       });
 
-    // Global Mute 
+    // Global Mute
     key(
       '⌘+shift+m ctrl+shift+m', () => {
         this.actions.app.toggleMuteApp();


### PR DESCRIPTION
### Description
Takes into consideration which services are displayed in the sidebar even if they are disabled (but not hidden) and computes the correct shortcut number for each one of them.

### Motivation and Context
Fixes https://github.com/meetfranz/franz/issues/350

### How Has This Been Tested?
Tested in Windows 10 64bits. Checked shortcut numbers when the option to show disabled services is checked and when it isn't.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).

