### PR TITLE
[PR] Add deep linking functionality

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,3 +34,7 @@ linux:
 nsis:
   perMachine: false
   oneClick: true
+
+protocols: 
+  name: Franz
+  schemes: [franz] 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Messaging app for WhatsApp, Slack, Telegram, HipChat, Hangouts and many many more.",
   "copyright": "adlk x franz - Stefan Malzner",
   "main": "index.js",
+  "homepage": "https://meetfranz.com",
   "repository": "https://github.com/meetfranz/franz.git",
   "private": true,
   "scripts": {

--- a/src/electron/deepLinking.js
+++ b/src/electron/deepLinking.js
@@ -1,5 +1,5 @@
-export default function handleDeepLink(window, url) {
-  console.log(url);
+export default function handleDeepLink(window, rawUrl) {
+  const url = rawUrl.replace('franz://', '');
 
   window.webContents.send('navigateFromDeepLink', { url });
 }

--- a/src/electron/deepLinking.js
+++ b/src/electron/deepLinking.js
@@ -1,0 +1,5 @@
+export default function handleDeepLink(window, url) {
+  console.log(url);
+
+  window.webContents.send('navigateFromDeepLink', { url });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { isDevMode, isWindows } from './environment';
 import ipcApi from './electron/ipc-api';
 import Tray from './lib/Tray';
 import Settings from './electron/Settings';
+import handleDeepLink from './electron/deepLinking';
 import { appId } from './package.json'; // eslint-disable-line import/no-unresolved
 import './electron/exception';
 
@@ -26,10 +27,18 @@ if (isWindows) {
 }
 
 // Force single window
-const isSecondInstance = app.makeSingleInstance(() => {
+const isSecondInstance = app.makeSingleInstance((argv) => {
   if (mainWindow) {
     if (mainWindow.isMinimized()) mainWindow.restore();
     mainWindow.focus();
+
+    if (process.platform === 'win32') {
+      // Keep only command line / deep linked arguments
+      const url = argv.slice(1);
+
+      console.log(url);
+      handleDeepLink(mainWindow, url);
+    }
   }
 });
 
@@ -70,7 +79,8 @@ const createWindow = () => {
   const trayIcon = new Tray();
 
   // Initialize ipcApi
-  ipcApi({ mainWindow, settings, trayIcon });
+  const franzIpcApi = ipcApi({ mainWindow, settings, trayIcon });
+  console.log(franzIpcApi);
 
   // Manage Window State
   mainWindowState.manage(mainWindow);
@@ -176,3 +186,15 @@ app.on('activate', () => {
     mainWindow.show();
   }
 });
+
+app.on('will-finish-launching', () => {
+  // Protocol handler for osx
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    console.log(`open-url event: ${url}`);
+    handleDeepLink(mainWindow, url);
+  });
+});
+
+// Register App URL
+app.setAsDefaultProtocolClient('franz');

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,8 @@ const createWindow = () => {
 
   mainWindow.on('show', () => {
     mainWindow.setSkipTaskbar(false);
+
+    handleDeepLink(mainWindow, 'franz://settings/services/add/msteams');
   });
 
   app.mainWindow = mainWindow;

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,10 @@ const isSecondInstance = app.makeSingleInstance((argv) => {
       // Keep only command line / deep linked arguments
       const url = argv.slice(1);
 
-      console.log(url);
-      handleDeepLink(mainWindow, url);
+      if (url) {
+        console.log(url.toString());
+        handleDeepLink(mainWindow, url.toString());
+      }
     }
   }
 });

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -116,6 +116,11 @@ export default class AppStore extends Store {
       }
     });
 
+    // Handle deep linking (franz://)
+    ipcRenderer.on('navigateFromDeepLink', (event, data) => {
+      console.log(event, data);
+    });
+
     // Check system idle time every minute
     setInterval(() => {
       this.idleTime = idleTimer.getIdleTime();

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -118,7 +118,10 @@ export default class AppStore extends Store {
 
     // Handle deep linking (franz://)
     ipcRenderer.on('navigateFromDeepLink', (event, data) => {
-      console.log(event, data);
+      const { url } = data;
+      if (!url) return;
+
+      this.stores.router.push(data.url);
     });
 
     // Check system idle time every minute


### PR DESCRIPTION
Enables external resources to control app routes via eg. `franz://settings/app`.
The available urls reflect the apps routes.

**Todo**
- [x] Test deep linking on Windows