### PR TITLE
Fix bug that allows negative badge notifications

### DIFF
--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -40,8 +40,8 @@ class RecipeWebview {
       && this.countCache.indirect === indirect) return;
 
     const count = {
-      direct,
-      indirect,
+      direct: direct > 0 ? direct : 0,
+      indirect: indirect > 0 ? indirect : 0,
     };
 
     ipcRenderer.sendToHost('messages', count);


### PR DESCRIPTION
### Description
Some plugins might have bugs where they allow for negative numbers in the badge:
![image](https://user-images.githubusercontent.com/5197675/33721450-f5ae50d8-db5e-11e7-83e0-6126edfc7740.png)


### Motivation and Context
This change is required so that if that bug is present in the plugin at least Franz won't go into negative numbers. Raised issue:
https://github.com/meetfranz/franz/issues/401

### How Has This Been Tested?
This was tested on a Mac. Used the broken Google Calendar plugin (fix for it here: https://github.com/meetfranz/plugins-legacy/pull/332) to replicate the issue:
* go to Google Calendar
* press Escape
* with this fix, the badge number should not decrease (without the fix, it goes into negative numbers) 

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. -->
