### PR TITLE
prevent drag event from bubbling

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -105,3 +105,5 @@ window.addEventListener('load', () => {
 // Prevent drag and drop into window from redirecting
 window.addEventListener('dragover', event => event.preventDefault());
 window.addEventListener('drop', event => event.preventDefault());
+window.addEventListener('dragover', event => event.stopPropagation());
+window.addEventListener('drop', event => event.stopPropagation());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Since dragging and dropping the window of Franz triggers bubbling (Dragging the window while Whatsapp is open causes the contact info bar to pop up), I used the method "event.stopPropagation()" in "app.js" on the events "dragover" and "drop" to prevent such actions from bubbling.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In response to issue #357, adding these two lines prevent unwanted bubbling events from getting triggered when we try to drag and drop the Franz window frame. Thus, when somone tries to drag the Franz window while Whatsapp is open, the contact info bar will longer pop out.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->

Closes #357 