### PR TITLE
[PR] Reload service root

### DIFF
--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -368,7 +368,7 @@ export default class ServicesStore extends Store {
     const service = this.one(serviceId);
     service.resetMessageCount();
 
-    service.webview.reload();
+    service.webview.loadURL(service.url);
   }
 
   @action _reloadActive() {


### PR DESCRIPTION
This PR fixes an issue with services getting stuck on external sites as Franz is built to display static web apps. 

<kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd> now navigates back to the `service.url` instead of just reloading.