### PR TITLE
Correctly restore window when clicking on a notification

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -9,7 +9,7 @@ import prettyBytes from 'pretty-bytes';
 import Store from './lib/Store';
 import Request from './lib/Request';
 import { CHECK_INTERVAL, DEFAULT_APP_SETTINGS } from '../config';
-import { isMac } from '../environment';
+import { isMac, isLinux, isWindows } from '../environment';
 import locales from '../i18n/translations';
 import { gaEvent } from '../lib/analytics';
 
@@ -179,8 +179,11 @@ export default class AppStore extends Store {
 
         this.actions.service.setActive({ serviceId });
 
-        if (!isMac) {
-          const mainWindow = remote.getCurrentWindow();
+        const mainWindow = remote.getCurrentWindow();
+
+        if (isWindows) {
+          mainWindow.restore();
+        } else if (isLinux) {
           mainWindow.show();
         }
       }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -181,7 +181,7 @@ export default class AppStore extends Store {
 
         if (!isMac) {
           const mainWindow = remote.getCurrentWindow();
-          mainWindow.restore();
+          mainWindow.show();
         }
       }
     };


### PR DESCRIPTION
### Description
I changed the way the window is restored in `src/stores/AppStore.js`.

### Motivation and Context
Fixes issue #645

### How Has This Been Tested?
- Operating System and version: Arch Linux, 4.15.2-2
- Desktop environment: Gnome 3.26.2

Tested with these states : minimized, hidden, maximized minimized, maximized hidden. The fix correctly restores the window with its previous settings.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
