### PR TITLE
Refactor settingsStore to use mobx-localstorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "mobx": "^3.1.0",
+    "mobx-localstorage": "^0.1.7",
     "mobx-react": "^4.1.0",
     "mobx-react-form": "^1.32.2",
     "mobx-react-router": "^3.1.2",

--- a/src/api/LocalApi.js
+++ b/src/api/LocalApi.js
@@ -4,18 +4,6 @@ export default class LocalApi {
     this.local = local;
   }
 
-  getSettings() {
-    return this.local.getAppSettings();
-  }
-
-  updateSettings(data) {
-    return this.local.updateAppSettings(data);
-  }
-
-  removeKey(key) {
-    return this.local.removeKey(key);
-  }
-
   getAppCacheSize() {
     return this.local.getAppCacheSize();
   }

--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -1,4 +1,5 @@
 import { remote } from 'electron';
+import localStorage from 'mobx-localstorage';
 import du from 'du';
 
 import { getServicePartitionsDirectory } from '../../helpers/service-helpers.js';

--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -1,5 +1,4 @@
 import { remote } from 'electron';
-import localStorage from 'mobx-localstorage';
 import du from 'du';
 
 import { getServicePartitionsDirectory } from '../../helpers/service-helpers.js';

--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -7,38 +7,6 @@ import { getServicePartitionsDirectory } from '../../helpers/service-helpers.js'
 const { session } = remote;
 
 export default class LocalApi {
-  // App
-  async updateAppSettings(data) {
-    const currentSettings = await this.getAppSettings();
-    const settings = Object.assign(currentSettings, data);
-
-    localStorage.setItem('app', JSON.stringify(settings));
-    console.debug('LocalApi::updateAppSettings resolves', settings);
-
-    return settings;
-  }
-
-  async getAppSettings() {
-    const settingsString = localStorage.getItem('app');
-    try {
-      const settings = JSON.parse(settingsString) || {};
-      console.debug('LocalApi::getAppSettings resolves', settings);
-
-      return settings;
-    } catch (err) {
-      return {};
-    }
-  }
-
-  async removeKey(key) {
-    const settings = await this.getAppSettings();
-
-    if (Object.hasOwnProperty.call(settings, key)) {
-      delete settings[key];
-      localStorage.setItem('app', JSON.stringify(settings));
-    }
-  }
-
   // Services
   async getAppCacheSize() {
     const partitionsDir = getServicePartitionsDirectory();

--- a/src/api/server/ServerApi.js
+++ b/src/api/server/ServerApi.js
@@ -3,6 +3,7 @@ import path from 'path';
 import tar from 'tar';
 import fs from 'fs-extra';
 import { remote } from 'electron';
+import localStorage from 'mobx-localstorage';
 
 import ServiceModel from '../../models/Service';
 import RecipePreviewModel from '../../models/RecipePreview';

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -2,7 +2,6 @@ import { observable, extendObservable } from 'mobx';
 import { DEFAULT_APP_SETTINGS } from '../config';
 
 export default class Settings {
-  @observable autoLaunchOnStart = DEFAULT_APP_SETTINGS.autoLaunchOnStart;
   @observable autoLaunchInBackground = DEFAULT_APP_SETTINGS.autoLaunchInBackground;
   @observable runInBackground = DEFAULT_APP_SETTINGS.runInBackground;
   @observable enableSystemTray = DEFAULT_APP_SETTINGS.enableSystemTray;

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -331,10 +331,7 @@ export default class AppStore extends Store {
   }
 
   // Helpers
-  async _appStartsCounter() {
-    // we need to wait until the settings request is resolved
-    await this.stores.settings.allSettingsRequest;
-
+  _appStartsCounter() {
     this.actions.settings.update({
       settings: {
         appStarts: (this.stores.settings.all.appStarts || 0) + 1,
@@ -345,10 +342,10 @@ export default class AppStore extends Store {
   async _autoStart() {
     this.autoLaunchOnStart = await this._checkAutoStart();
 
-    // we need to wait until the settings request is resolved
-    await this.stores.settings.allSettingsRequest;
+    console.log('### settings appstarts', this.stores.settings.all.appStarts);
 
     if (!this.stores.settings.all.appStarts) {
+      console.log('launch Franz on start');
       this.actions.app.launchOnStartup({
         enable: true,
       });

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -342,10 +342,7 @@ export default class AppStore extends Store {
   async _autoStart() {
     this.autoLaunchOnStart = await this._checkAutoStart();
 
-    console.log('### settings appstarts', this.stores.settings.all.appStarts);
-
     if (!this.stores.settings.all.appStarts) {
-      console.log('launch Franz on start');
       this.actions.app.launchOnStartup({
         enable: true,
       });

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -342,7 +342,7 @@ export default class AppStore extends Store {
   async _autoStart() {
     this.autoLaunchOnStart = await this._checkAutoStart();
 
-    if (!this.stores.settings.all.appStarts) {
+    if (this.stores.settings.all.appStarts === 1) {
       this.actions.app.launchOnStartup({
         enable: true,
       });

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -536,7 +536,6 @@ export default class ServicesStore extends Store {
 
     // We can't just block this earlier, otherwise the mobx reaction won't be aware of the vars to watch in some cases
     if (showMessageBadgesEvenWhenMuted) {
-      console.log('set badge', unreadDirectMessageCount, unreadIndirectMessageCount);
       this.actions.app.setBadge({
         unreadDirectMessageCount,
         unreadIndirectMessageCount,

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import { action, computed, observable, extendObservable } from 'mobx';
+import { action, computed, observable } from 'mobx';
 import localStorage from 'mobx-localstorage';
 
 import Store from './lib/Store';

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -1,18 +1,12 @@
 import { ipcRenderer } from 'electron';
-import { action, computed, observable } from 'mobx';
+import { action, computed } from 'mobx';
 import localStorage from 'mobx-localstorage';
 
 import Store from './lib/Store';
-import Request from './lib/Request';
-import CachedRequest from './lib/CachedRequest';
 import { gaEvent } from '../lib/analytics';
 import SettingsModel from '../models/Settings';
 
 export default class SettingsStore extends Store {
-  @observable allSettingsRequest = new CachedRequest(this.api.local, 'getSettings');
-  @observable updateSettingsRequest = new Request(this.api.local, 'updateSettings');
-  @observable removeSettingsKeyRequest = new Request(this.api.local, 'removeKey');
-
   constructor(...args) {
     super(...args);
 
@@ -22,7 +16,6 @@ export default class SettingsStore extends Store {
   }
 
   setup() {
-    this.allSettingsRequest.execute();
     this._shareSettingsWithMainProcess();
   }
 

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -26,15 +26,19 @@ export default class SettingsStore extends Store {
   }
 
   @computed get all() {
+    console.log('get all settings');
     return new SettingsModel(this.allSettingsRequest.result);
   }
 
   @action async _update({ settings }) {
     await this.updateSettingsRequest.execute(settings)._promise;
-    await this.allSettingsRequest.patch((result) => {
-      if (!result) return;
-      extendObservable(result, settings);
-    });
+    // await this.allSettingsRequest.patch((result) => {
+    //   if (!result) return;
+    //   console.log(result.runInBackground, settings.runInBackground);
+    //   extendObservable(result, settings);
+    //   console.log(result.runInBackground);
+    //   // result.update(settings);
+    // });
 
     // We need a little hack to wait until everything is patched
     setTimeout(() => this._shareSettingsWithMainProcess(), 0);

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -1,6 +1,7 @@
 import { observable, computed, action } from 'mobx';
 import moment from 'moment';
 import jwt from 'jsonwebtoken';
+import localStorage from 'mobx-localstorage';
 
 import { isDevMode } from '../environment';
 import Store from './lib/Store';
@@ -99,7 +100,7 @@ export default class UserStore extends Store {
 
   // Data
   @computed get isLoggedIn() {
-    return this.authToken !== null && this.authToken !== undefined;
+    return Boolean(localStorage.getItem('authToken'));
   }
 
   // @computed get isTokenValid() {
@@ -225,6 +226,7 @@ export default class UserStore extends Store {
 
   // This is a mobx autorun which forces the user to login if not authenticated
   _requireAuthenticatedUser = () => {
+    console.log('requireAuthenticatedUser');
     if (this.isTokenExpired) {
       this._logout();
     }

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -226,7 +226,6 @@ export default class UserStore extends Store {
 
   // This is a mobx autorun which forces the user to login if not authenticated
   _requireAuthenticatedUser = () => {
-    console.log('requireAuthenticatedUser');
     if (this.isTokenExpired) {
       this._logout();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4270,6 +4270,10 @@ mksnapshot@^0.3.0:
     fs-extra "0.26.7"
     request "^2.79.0"
 
+mobx-localstorage@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/mobx-localstorage/-/mobx-localstorage-0.1.7.tgz#c0c64366769f390ca4a333f41912eae00cd4a9de"
+
 mobx-react-form@^1.32.2:
   version "1.32.2"
   resolved "https://registry.yarnpkg.com/mobx-react-form/-/mobx-react-form-1.32.2.tgz#5610dd0e4fab006acf2daf1becbedecad182a5a0"


### PR DESCRIPTION
### Description
The settingsStores request architecture was too complex and error prone when used with localstorage. localstorage is now used via mobx-localstorage everywhere which allows us to remove all of the `request` design for the `SettingsStore`.

### Motivation and Context
Patching changes in app settings did not work properly when the changed key did not already exist in localstorage. This was also one of the reasons why some settings toggles did not allow to turn off/on.

This refactor is also solving issues with not being able to disable autostart as mentioned in #689 and #629

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).

closes #615, closes #689, closes #629
