### PR TITLE
[WIP] feat(App): Feature Added possibility to hide Dock icon

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -8,6 +8,7 @@ import Form from '../../../lib/Form';
 import Button from '../../ui/Button';
 import Toggle from '../../ui/Toggle';
 import Select from '../../ui/Select';
+import Appear from '../../ui/effects/Appear';
 
 import { FRANZ_TRANSLATION } from '../../../config';
 
@@ -149,6 +150,13 @@ export default class EditSettingsForm extends Component {
             <Toggle field={form.$('autoLaunchOnStart')} />
             <Toggle field={form.$('runInBackground')} />
             <Toggle field={form.$('enableSystemTray')} />
+            {process.platform === 'darwin' && form.$('enableSystemTray').value && (
+              <Appear>
+                <div className="settings__toggle--nested">
+                  <Toggle field={form.$('hideDockIcon')} />
+                </div>
+              </Appear>
+            )}
             {process.platform === 'win32' && (
               <Toggle field={form.$('minimizeToSystemTray')} />
             )}

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ export const DEFAULT_APP_SETTINGS = {
   runInBackground: true,
   enableSystemTray: true,
   minimizeToSystemTray: false,
+  hideDockIcon: false,
   showDisabledServices: true,
   showMessageBadgeWhenMuted: true,
   enableSpellchecking: true,

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -10,7 +10,7 @@ import Form from '../../lib/Form';
 import { APP_LOCALES } from '../../i18n/languages';
 import { gaPage } from '../../lib/analytics';
 import { DEFAULT_APP_SETTINGS } from '../../config';
-
+import { isMac } from '../../environment';
 
 import EditSettingsForm from '../../components/settings/settings/EditSettingsForm';
 
@@ -34,6 +34,14 @@ const messages = defineMessages({
   minimizeToSystemTray: {
     id: 'settings.app.form.minimizeToSystemTray',
     defaultMessage: '!!!Minimize Franz to system tray',
+  },
+  enableMenuBar: {
+    id: 'settings.app.form.enableMenuBar',
+    defaultMessage: '!!!Show Franz in Menu Bar',
+  },
+  hideDockIcon: {
+    id: 'settings.app.form.hideDockIcon',
+    defaultMessage: '!!!Hide Franz Dock icon',
   },
   language: {
     id: 'settings.app.form.language',
@@ -88,6 +96,7 @@ export default class EditSettingsScreen extends Component {
         runInBackground: settingsData.runInBackground,
         enableSystemTray: settingsData.enableSystemTray,
         minimizeToSystemTray: settingsData.minimizeToSystemTray,
+        hideDockIcon: settingsData.hideDockIcon,
         showDisabledServices: settingsData.showDisabledServices,
         showMessageBadgeWhenMuted: settingsData.showMessageBadgeWhenMuted,
         enableSpellchecking: settingsData.enableSpellchecking,
@@ -145,7 +154,7 @@ export default class EditSettingsScreen extends Component {
           default: DEFAULT_APP_SETTINGS.runInBackground,
         },
         enableSystemTray: {
-          label: intl.formatMessage(messages.enableSystemTray),
+          label: intl.formatMessage(isMac ? messages.enableMenuBar : messages.enableSystemTray),
           value: settings.all.enableSystemTray,
           default: DEFAULT_APP_SETTINGS.enableSystemTray,
         },
@@ -153,6 +162,11 @@ export default class EditSettingsScreen extends Component {
           label: intl.formatMessage(messages.minimizeToSystemTray),
           value: settings.all.minimizeToSystemTray,
           default: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
+        },
+        hideDockIcon: {
+          label: intl.formatMessage(messages.hideDockIcon),
+          value: settings.all.hideDockIcon,
+          default: DEFAULT_APP_SETTINGS.hideDockIcon,
         },
         showDisabledServices: {
           label: intl.formatMessage(messages.showDisabledServices),

--- a/src/electron/Settings.js
+++ b/src/electron/Settings.js
@@ -9,6 +9,7 @@ export default class Settings {
     runInBackground: DEFAULT_APP_SETTINGS.runInBackground,
     enableSystemTray: DEFAULT_APP_SETTINGS.enableSystemTray,
     minimizeToSystemTray: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
+    hideDockIcon: DEFAULT_APP_SETTINGS.hideDockIcon,
     locale: DEFAULT_APP_SETTINGS.locale,
     beta: DEFAULT_APP_SETTINGS.beta,
   };

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -159,6 +159,8 @@
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.enableSystemTray": "Show Franz in system tray",
   "settings.app.form.minimizeToSystemTray": "Minimize Franz to system tray",
+  "settings.app.form.enableMenuBar": "Show Franz in Menu Bar",
+  "settings.app.form.hideDockIcon": "Hide Franz Dock icon",
   "settings.app.form.runInBackground": "Keep Franz in background when closing the window",
   "settings.app.form.language": "Language",
   "settings.app.form.enableSpellchecking": "Enable spell checking",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import path from 'path';
 
 import windowStateKeeper from 'electron-window-state';
 
-import { isDevMode, isWindows } from './environment';
+import { isDevMode, isWindows, isMac } from './environment';
 import ipcApi from './electron/ipc-api';
 import Tray from './lib/Tray';
 import Settings from './electron/Settings';
@@ -110,6 +110,10 @@ const createWindow = () => {
       if (isWindows && settings.get('minimizeToSystemTray')) {
         mainWindow.setSkipTaskbar(true);
       }
+
+      if (isMac && settings.get('enableSystemTray') && settings.get('hideDockIcon')) {
+        app.dock.hide();
+      }
     } else {
       app.quit();
     }
@@ -147,6 +151,9 @@ const createWindow = () => {
   });
 
   mainWindow.on('show', () => {
+    if (isMac && settings.get('enableSystemTray') && settings.get('hideDockIcon')) {
+      app.dock.show();
+    }
     mainWindow.setSkipTaskbar(false);
   });
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -22,7 +22,9 @@ const template = [
         role: 'cut',
       },
       {
-        role: 'copy',
+        label: 'Copy',
+        accelerator: 'Cmd+C',
+        selector: 'copy:',
       },
       {
         role: 'paste',
@@ -69,6 +71,13 @@ const template = [
   {
     role: 'window',
     submenu: [
+      {
+        label: 'Show Main Window',
+        click() { app.mainWindow.show(); },
+      },
+      {
+        type: 'separator',
+      },
       {
         role: 'minimize',
       },
@@ -125,10 +134,15 @@ export default class FranzMenu {
 
     tpl[1].submenu.push({
       role: 'toggledevtools',
+      click: () => {
+        app.mainWindow.show();
+      },
     }, {
       label: 'Toggle Service Developer Tools',
       accelerator: 'CmdOrCtrl+Shift+Alt+i',
       click: () => {
+        app.mainWindow.show();
+
         this.actions.service.openDevToolsForActiveService();
       },
     });
@@ -138,6 +152,8 @@ export default class FranzMenu {
       id: 'reloadService',
       accelerator: 'CmdOrCtrl+R',
       click: () => {
+        app.mainWindow.show();
+
         if (this.stores.user.isLoggedIn
           && this.stores.services.enabled.length > 0) {
           this.actions.service.reloadActive();
@@ -149,6 +165,8 @@ export default class FranzMenu {
       label: 'Reload Franz',
       accelerator: 'CmdOrCtrl+Shift+R',
       click: () => {
+        app.mainWindow.show();
+
         window.location.reload();
       },
     });
@@ -167,6 +185,8 @@ export default class FranzMenu {
             label: 'Settings',
             accelerator: 'CmdOrCtrl+,',
             click: () => {
+              app.mainWindow.show();
+
               this.actions.ui.openSettings({ path: 'app' });
             },
           },
@@ -234,6 +254,8 @@ export default class FranzMenu {
       label: 'Add new Service',
       accelerator: 'CmdOrCtrl+N',
       click: () => {
+        app.mainWindow.show();
+
         this.actions.ui.openSettings({ path: 'recipes' });
       },
     }, {
@@ -258,6 +280,8 @@ export default class FranzMenu {
         type: 'radio',
         checked: service.isActive,
         click: () => {
+          app.mainWindow.show();
+
           this.actions.service.setActive({ serviceId: service.id });
         },
       }));

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -7,6 +7,7 @@ export default class Settings {
   @observable runInBackground = DEFAULT_APP_SETTINGS.runInBackground;
   @observable enableSystemTray = DEFAULT_APP_SETTINGS.enableSystemTray;
   @observable minimizeToSystemTray = DEFAULT_APP_SETTINGS.minimizeToSystemTray;
+  @observable hideDockIcon = DEFAULT_APP_SETTINGS.hideDockIcon;
   @observable showDisabledServices = DEFAULT_APP_SETTINGS.showDisabledServices;
   @observable showMessageBadgeWhenMuted = DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted;
   @observable enableSpellchecking = DEFAULT_APP_SETTINGS.enableSpellchecking;

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -229,6 +229,10 @@
     }
   }
 
+  .settings__toggle--nested {
+    padding-left: 40px; /* alternatively 20px or 60px */
+  }
+
   .account {
     height: auto;
     // padding: 20px;

--- a/src/webview/notifications.js
+++ b/src/webview/notifications.js
@@ -1,5 +1,7 @@
-const { ipcRenderer } = require('electron');
+const { remote, ipcRenderer } = require('electron');
 const uuidV1 = require('uuid/v1');
+
+const { app } = remote;
 
 class Notification {
   static permission = 'granted';
@@ -16,6 +18,8 @@ class Notification {
     }));
 
     ipcRenderer.once(`notification-onclick:${this.notificationId}`, () => {
+      app.mainWindow.show();
+
       if (typeof this.onclick === 'function') {
         this.onclick();
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

If you close the main window without quitting the app (run in background: on), the Dock icon for Franz is hidden (as well as in the App Switcher). Showing Franz from the Menu Bar icon, restores the Franz window and consequently the icons too.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Hiding the Franz Dock icon is a feature wanted by the community: Franz should be able to live in the Menu Bar only.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

[WIP]

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
