### PR TITLE
Split settings data stores

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -2,9 +2,11 @@ import PropTypes from 'prop-types';
 
 export default {
   update: {
-    settings: PropTypes.object.isRequired,
+    type: PropTypes.string.isRequired,
+    data: PropTypes.object.isRequired,
   },
   remove: {
+    type: PropTypes.string.isRequired,
     key: PropTypes.string.isRequired,
   },
 };

--- a/src/api/LocalApi.js
+++ b/src/api/LocalApi.js
@@ -4,6 +4,14 @@ export default class LocalApi {
     this.local = local;
   }
 
+  getAppSettings() {
+    return this.local.getAppSettings();
+  }
+
+  updateAppSettings(data) {
+    return this.local.updateAppSettings(data);
+  }
+
   getAppCacheSize() {
     return this.local.getAppCacheSize();
   }

--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -1,4 +1,4 @@
-import { remote } from 'electron';
+import { ipcRenderer, remote } from 'electron';
 import du from 'du';
 
 import { getServicePartitionsDirectory } from '../../helpers/service-helpers.js';
@@ -8,6 +8,23 @@ const debug = require('debug')('LocalApi');
 const { session } = remote;
 
 export default class LocalApi {
+  // Settings
+  getAppSettings() {
+    return new Promise((resolve) => {
+      ipcRenderer.once('appSettings', (event, data) => {
+        debug('LocalApi::getAppSettings resolves', data);
+        resolve(data);
+      });
+
+      ipcRenderer.send('getAppSettings');
+    });
+  }
+
+  async updateAppSettings(data) {
+    debug('LocalApi::updateAppSettings resolves', data);
+    ipcRenderer.send('updateAppSettings', data);
+  }
+
   // Services
   async getAppCacheSize() {
     const partitionsDir = getServicePartitionsDirectory();

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,8 @@
+import electron from 'electron';
+import path from 'path';
+
+const app = process.type === 'renderer' ? electron.remote.app : electron.app;
+
 export const CHECK_INTERVAL = 1000 * 3600; // How often should we perform checks
 export const LOCAL_API = 'http://localhost:3000';
 export const DEV_API = 'https://dev.franzinfra.com';
@@ -13,7 +18,6 @@ export const DEFAULT_APP_SETTINGS = {
   showDisabledServices: true,
   showMessageBadgeWhenMuted: true,
   enableSpellchecking: true,
-  // spellcheckingLanguage: 'auto',
   locale: '',
   fallbackLocale: 'en-US',
   beta: false,
@@ -22,3 +26,5 @@ export const DEFAULT_APP_SETTINGS = {
 
 export const FRANZ_SERVICE_REQUEST = 'http://bit.ly/franz-service-request';
 export const FRANZ_TRANSLATION = 'http://bit.ly/franz-translate';
+
+export const SETTINGS_PATH = path.join(app.getPath('userData'), 'config', 'settings.json');

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,6 @@ export const LIVE_API = 'https://api.franzinfra.com';
 export const GA_ID = 'UA-74126766-6';
 
 export const DEFAULT_APP_SETTINGS = {
-  autoLaunchOnStart: true,
   autoLaunchInBackground: false,
   runInBackground: true,
   enableSystemTray: true,

--- a/src/containers/layout/AppLayoutContainer.js
+++ b/src/containers/layout/AppLayoutContainer.js
@@ -77,7 +77,7 @@ export default class AppLayoutContainer extends Component {
       <Sidebar
         services={services.allDisplayed}
         setActive={setActive}
-        isAppMuted={settings.all.isAppMuted}
+        isAppMuted={settings.all.app.isAppMuted}
         openSettings={openSettings}
         closeSettings={closeSettings}
         reorder={reorder}
@@ -87,7 +87,7 @@ export default class AppLayoutContainer extends Component {
         deleteService={deleteService}
         updateService={updateService}
         toggleMuteApp={toggleMuteApp}
-        showMessageBadgeWhenMutedSetting={settings.all.showMessageBadgeWhenMuted}
+        showMessageBadgeWhenMutedSetting={settings.all.app.showMessageBadgeWhenMuted}
         showMessageBadgesEvenWhenMuted={ui.showMessageBadgesEvenWhenMuted}
       />
     );
@@ -99,7 +99,7 @@ export default class AppLayoutContainer extends Component {
         setWebviewReference={setWebviewReference}
         openWindow={openWindow}
         reload={reload}
-        isAppMuted={settings.all.isAppMuted}
+        isAppMuted={settings.all.app.isAppMuted}
         update={updateService}
       />
     );

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -91,15 +91,13 @@ export default class EditSettingsScreen extends Component {
         showDisabledServices: settingsData.showDisabledServices,
         showMessageBadgeWhenMuted: settingsData.showMessageBadgeWhenMuted,
         enableSpellchecking: settingsData.enableSpellchecking,
-        // spellcheckingLanguage: settingsData.spellcheckingLanguage,
-        locale: settingsData.locale,
-        beta: settingsData.beta,
       },
     });
 
     user.update({
       userData: {
         beta: settingsData.beta,
+        locale: settingsData.locale,
       },
     });
   }
@@ -169,12 +167,6 @@ export default class EditSettingsScreen extends Component {
           value: settings.all.enableSpellchecking,
           default: DEFAULT_APP_SETTINGS.enableSpellchecking,
         },
-        // spellcheckingLanguage: {
-        //   label: intl.formatMessage(messages.spellcheckingLanguage),
-        //   value: settings.all.spellcheckingLanguage,
-        //   options: spellcheckerLocales,
-        //   default: DEFAULT_APP_SETTINGS.spellcheckingLanguage,
-        // },
         locale: {
           label: intl.formatMessage(messages.language),
           value: app.locale,

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -55,10 +55,6 @@ const messages = defineMessages({
     id: 'settings.app.form.spellcheckingLanguage',
     defaultMessage: '!!!Language for spell checking',
   },
-  // spellcheckingAutomaticDetection: {
-  //   id: 'settings.app.form.spellcheckingAutomaticDetection',
-  //   defaultMessage: '!!!Detect language automatically',
-  // },
   beta: {
     id: 'settings.app.form.beta',
     defaultMessage: '!!!Include beta versions',
@@ -84,13 +80,16 @@ export default class EditSettingsScreen extends Component {
     });
 
     settings.update({
-      settings: {
+      type: 'app',
+      data: {
         runInBackground: settingsData.runInBackground,
         enableSystemTray: settingsData.enableSystemTray,
         minimizeToSystemTray: settingsData.minimizeToSystemTray,
         showDisabledServices: settingsData.showDisabledServices,
         showMessageBadgeWhenMuted: settingsData.showMessageBadgeWhenMuted,
         enableSpellchecking: settingsData.enableSpellchecking,
+        beta: settingsData.beta, // we need this info in the main process as well
+        locale: settingsData.locale, // we need this info in the main process as well
       },
     });
 
@@ -114,17 +113,6 @@ export default class EditSettingsScreen extends Component {
       });
     });
 
-    // const spellcheckerLocales = [{
-    //   value: 'auto',
-    //   label: intl.formatMessage(messages.spellcheckingAutomaticDetection),
-    // }];
-    // Object.keys(SPELLCHECKER_LOCALES).forEach((key) => {
-    //   spellcheckerLocales.push({
-    //     value: key,
-    //     label: SPELLCHECKER_LOCALES[key],
-    //   });
-    // });
-
     const config = {
       fields: {
         autoLaunchOnStart: {
@@ -139,32 +127,32 @@ export default class EditSettingsScreen extends Component {
         },
         runInBackground: {
           label: intl.formatMessage(messages.runInBackground),
-          value: settings.all.runInBackground,
+          value: settings.all.app.runInBackground,
           default: DEFAULT_APP_SETTINGS.runInBackground,
         },
         enableSystemTray: {
           label: intl.formatMessage(messages.enableSystemTray),
-          value: settings.all.enableSystemTray,
+          value: settings.all.app.enableSystemTray,
           default: DEFAULT_APP_SETTINGS.enableSystemTray,
         },
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),
-          value: settings.all.minimizeToSystemTray,
+          value: settings.all.app.minimizeToSystemTray,
           default: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
         },
         showDisabledServices: {
           label: intl.formatMessage(messages.showDisabledServices),
-          value: settings.all.showDisabledServices,
+          value: settings.all.app.showDisabledServices,
           default: DEFAULT_APP_SETTINGS.showDisabledServices,
         },
         showMessageBadgeWhenMuted: {
           label: intl.formatMessage(messages.showMessageBadgeWhenMuted),
-          value: settings.all.showMessageBadgeWhenMuted,
+          value: settings.all.app.showMessageBadgeWhenMuted,
           default: DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
         },
         enableSpellchecking: {
           label: intl.formatMessage(messages.enableSpellchecking),
-          value: settings.all.enableSpellchecking,
+          value: settings.all.app.enableSpellchecking,
           default: DEFAULT_APP_SETTINGS.enableSpellchecking,
         },
         locale: {

--- a/src/electron/Settings.js
+++ b/src/electron/Settings.js
@@ -6,18 +6,7 @@ import { SETTINGS_PATH, DEFAULT_APP_SETTINGS } from '../config';
 const debug = require('debug')('Settings');
 
 export default class Settings {
-  @observable store = {
-    autoLaunchInBackground: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
-    runInBackground: DEFAULT_APP_SETTINGS.runInBackground,
-    enableSystemTray: DEFAULT_APP_SETTINGS.enableSystemTray,
-    minimizeToSystemTray: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
-    locale: DEFAULT_APP_SETTINGS.locale,
-    beta: DEFAULT_APP_SETTINGS.beta,
-    isAppMuted: DEFAULT_APP_SETTINGS.isAppMuted,
-    showMessageBadgeWhenMuted: DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
-    showDisabledServices: DEFAULT_APP_SETTINGS.showDisabledServices,
-    enableSpellchecking: DEFAULT_APP_SETTINGS.enableSpellchecking,
-  };
+  @observable store = DEFAULT_APP_SETTINGS;
 
   constructor() {
     if (!pathExistsSync(SETTINGS_PATH)) {

--- a/src/electron/Settings.js
+++ b/src/electron/Settings.js
@@ -1,27 +1,53 @@
-import { observable } from 'mobx';
+import { observable, toJS } from 'mobx';
+import { pathExistsSync, outputJsonSync, readJsonSync } from 'fs-extra';
 
-import { DEFAULT_APP_SETTINGS } from '../config';
+import { SETTINGS_PATH, DEFAULT_APP_SETTINGS } from '../config';
+
+const debug = require('debug')('Settings');
 
 export default class Settings {
   @observable store = {
-    autoLaunchOnStart: DEFAULT_APP_SETTINGS.autoLaunchOnStart,
     autoLaunchInBackground: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
     runInBackground: DEFAULT_APP_SETTINGS.runInBackground,
     enableSystemTray: DEFAULT_APP_SETTINGS.enableSystemTray,
     minimizeToSystemTray: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
     locale: DEFAULT_APP_SETTINGS.locale,
     beta: DEFAULT_APP_SETTINGS.beta,
+    isAppMuted: DEFAULT_APP_SETTINGS.isAppMuted,
+    showMessageBadgeWhenMuted: DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
+    showDisabledServices: DEFAULT_APP_SETTINGS.showDisabledServices,
+    enableSpellchecking: DEFAULT_APP_SETTINGS.enableSpellchecking,
   };
+
+  constructor() {
+    if (!pathExistsSync(SETTINGS_PATH)) {
+      this._writeFile();
+    } else {
+      this._hydrate();
+    }
+  }
 
   set(settings) {
     this.store = Object.assign(this.store, settings);
+
+    this._writeFile();
   }
 
-  all() {
+  get all() {
     return this.store;
   }
 
   get(key) {
     return this.store[key];
+  }
+
+  _hydrate() {
+    this.store = readJsonSync(SETTINGS_PATH);
+    debug('Hydrate store', toJS(this.store));
+  }
+
+  _writeFile() {
+    outputJsonSync(SETTINGS_PATH, this.store);
+    debug('Write settings file', toJS(this.store));
   }
 }

--- a/src/electron/ipc-api/settings.js
+++ b/src/electron/ipc-api/settings.js
@@ -4,4 +4,12 @@ export default (params) => {
   ipcMain.on('settings', (event, args) => {
     params.settings.set(args);
   });
+
+  ipcMain.on('getAppSettings', () => {
+    params.mainWindow.webContents.send('appSettings', params.settings.all);
+  });
+
+  ipcMain.on('updateAppSettings', (event, args) => {
+    params.settings.set(args);
+  });
 };

--- a/src/electron/ipc-api/settings.js
+++ b/src/electron/ipc-api/settings.js
@@ -1,10 +1,6 @@
 import { ipcMain } from 'electron';
 
 export default (params) => {
-  ipcMain.on('settings', (event, args) => {
-    params.settings.set(args);
-  });
-
   ipcMain.on('getAppSettings', () => {
     params.mainWindow.webContents.send('appSettings', params.settings.all);
   });

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -2,19 +2,38 @@ import { observable, extendObservable } from 'mobx';
 import { DEFAULT_APP_SETTINGS } from '../config';
 
 export default class Settings {
-  @observable autoLaunchInBackground = DEFAULT_APP_SETTINGS.autoLaunchInBackground;
-  @observable runInBackground = DEFAULT_APP_SETTINGS.runInBackground;
-  @observable enableSystemTray = DEFAULT_APP_SETTINGS.enableSystemTray;
-  @observable minimizeToSystemTray = DEFAULT_APP_SETTINGS.minimizeToSystemTray;
-  @observable showDisabledServices = DEFAULT_APP_SETTINGS.showDisabledServices;
-  @observable showMessageBadgeWhenMuted = DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted;
-  @observable enableSpellchecking = DEFAULT_APP_SETTINGS.enableSpellchecking;
-  @observable locale = DEFAULT_APP_SETTINGS.locale;
-  @observable beta = DEFAULT_APP_SETTINGS.beta;
-  @observable isAppMuted = DEFAULT_APP_SETTINGS.isAppMuted;
+  @observable app = {
+    autoLaunchInBackground: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
+    runInBackground: DEFAULT_APP_SETTINGS.runInBackground,
+    enableSystemTray: DEFAULT_APP_SETTINGS.enableSystemTray,
+    minimizeToSystemTray: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
+    isAppMuted: DEFAULT_APP_SETTINGS.isAppMuted,
+    showMessageBadgeWhenMuted: DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
+    showDisabledServices: DEFAULT_APP_SETTINGS.showDisabledServices,
+    enableSpellchecking: DEFAULT_APP_SETTINGS.enableSpellchecking,
+    locale: DEFAULT_APP_SETTINGS.locale,
+    beta: DEFAULT_APP_SETTINGS.beta,
 
-  constructor(data) {
-    Object.assign(this, data);
+  }
+
+  @observable service = {
+    activeService: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
+  }
+
+  @observable group = {
+    collapsed: [],
+    disabled: [],
+  }
+
+  @observable stats = {
+    appStarts: 0,
+  }
+
+  constructor({ app, service, group, stats }) {
+    Object.assign(this.app, app);
+    Object.assign(this.service, service);
+    Object.assign(this.group, group);
+    Object.assign(this.stats, stats);
   }
 
   update(data) {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -29,11 +29,14 @@ export default class Settings {
     appStarts: 0,
   }
 
-  constructor({ app, service, group, stats }) {
+  @observable migration = {}
+
+  constructor({ app, service, group, stats, migration }) {
     Object.assign(this.app, app);
     Object.assign(this.service, service);
     Object.assign(this.group, group);
     Object.assign(this.stats, stats);
+    Object.assign(this.migration, migration);
   }
 
   update(data) {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -2,19 +2,7 @@ import { observable, extendObservable } from 'mobx';
 import { DEFAULT_APP_SETTINGS } from '../config';
 
 export default class Settings {
-  @observable app = {
-    autoLaunchInBackground: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
-    runInBackground: DEFAULT_APP_SETTINGS.runInBackground,
-    enableSystemTray: DEFAULT_APP_SETTINGS.enableSystemTray,
-    minimizeToSystemTray: DEFAULT_APP_SETTINGS.minimizeToSystemTray,
-    isAppMuted: DEFAULT_APP_SETTINGS.isAppMuted,
-    showMessageBadgeWhenMuted: DEFAULT_APP_SETTINGS.showMessageBadgeWhenMuted,
-    showDisabledServices: DEFAULT_APP_SETTINGS.showDisabledServices,
-    enableSpellchecking: DEFAULT_APP_SETTINGS.enableSpellchecking,
-    locale: DEFAULT_APP_SETTINGS.locale,
-    beta: DEFAULT_APP_SETTINGS.beta,
-
-  }
+  @observable app = DEFAULT_APP_SETTINGS
 
   @observable service = {
     activeService: DEFAULT_APP_SETTINGS.autoLaunchInBackground,

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -5,7 +5,7 @@ export default class Settings {
   @observable app = DEFAULT_APP_SETTINGS
 
   @observable service = {
-    activeService: DEFAULT_APP_SETTINGS.autoLaunchInBackground,
+    activeService: '',
   }
 
   @observable group = {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -15,6 +15,7 @@ export default class User {
   @observable donor = {};
   @observable isDonor = false;
   @observable isMiner = false;
+  @observable locale = false;
 
   constructor(data) {
     if (!data.id) {
@@ -33,5 +34,6 @@ export default class User {
     this.isDonor = data.isDonor || this.isDonor;
     this.isSubscriptionOwner = data.isSubscriptionOwner || this.isSubscriptionOwner;
     this.isMiner = data.isMiner || this.isMiner;
+    this.locale = data.locale || this.locale;
   }
 }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -282,7 +282,11 @@ export default class AppStore extends Store {
   }
 
   _setLocale() {
-    const { locale } = this.stores.user.data;
+    let locale;
+    if (this.stores.user.isLoggedIn) {
+      locale = this.stores.user.data.locale;
+    }
+
 
     if (locale && Object.prototype.hasOwnProperty.call(locales, locale) && locale !== this.locale) {
       this.locale = locale;

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -159,7 +159,7 @@ export default class AppStore extends Store {
 
   // Actions
   @action _notify({ title, options, notificationId, serviceId = null }) {
-    if (this.stores.settings.all.isAppMuted) return;
+    if (this.stores.settings.all.app.isAppMuted) return;
 
     const notification = new window.Notification(title, options);
     notification.onclick = (e) => {
@@ -240,14 +240,15 @@ export default class AppStore extends Store {
     this.isSystemMuteOverridden = overrideSystemMute;
 
     this.actions.settings.update({
-      settings: {
+      type: 'app',
+      data: {
         isAppMuted: isMuted,
       },
     });
   }
 
   @action _toggleMuteApp() {
-    this._muteApp({ isMuted: !this.stores.settings.all.isAppMuted });
+    this._muteApp({ isMuted: !this.stores.settings.all.app.isAppMuted });
   }
 
   @action async _clearAllCache() {
@@ -331,8 +332,9 @@ export default class AppStore extends Store {
   // Helpers
   _appStartsCounter() {
     this.actions.settings.update({
-      settings: {
-        appStarts: (this.stores.settings.all.appStarts || 0) + 1,
+      type: 'stats',
+      data: {
+        appStarts: (this.stores.settings.all.stats.appStarts || 0) + 1,
       },
     });
   }
@@ -340,7 +342,8 @@ export default class AppStore extends Store {
   async _autoStart() {
     this.autoLaunchOnStart = await this._checkAutoStart();
 
-    if (this.stores.settings.all.appStarts === 1) {
+    if (this.stores.settings.all.stats.appStarts === 1) {
+      debug('Set app to launch on start');
       this.actions.app.launchOnStartup({
         enable: true,
       });
@@ -353,7 +356,7 @@ export default class AppStore extends Store {
 
   _systemDND() {
     const dnd = getDoNotDisturb();
-    if (dnd !== this.stores.settings.all.isAppMuted && !this.isSystemMuteOverridden) {
+    if (dnd !== this.stores.settings.all.app.isAppMuted && !this.isSystemMuteOverridden) {
       this.actions.app.muteApp({
         isMuted: dnd,
         overrideSystemMute: false,

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -15,6 +15,8 @@ import { gaEvent } from '../lib/analytics';
 
 import { getServiceIdsFromPartitions, removeServicePartitionDirectory } from '../helpers/service-helpers.js';
 
+const debug = require('debug')('AppStore');
+
 const { app } = remote;
 
 const defaultLocale = DEFAULT_APP_SETTINGS.locale;
@@ -279,13 +281,15 @@ export default class AppStore extends Store {
   }
 
   _setLocale() {
-    const locale = this.stores.settings.all.locale;
+    const { locale } = this.stores.user.data;
 
     if (locale && Object.prototype.hasOwnProperty.call(locales, locale) && locale !== this.locale) {
       this.locale = locale;
     } else if (!locale) {
       this.locale = this._getDefaultLocale();
     }
+
+    debug(`Set locale to "${this.locale}"`);
   }
 
   _getDefaultLocale() {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -86,13 +86,13 @@ export default class ServicesStore extends Store {
   }
 
   @computed get allDisplayed() {
-    return this.stores.settings.all.service.showDisabledServices ? this.all : this.enabled;
+    return this.stores.settings.all.app.showDisabledServices ? this.all : this.enabled;
   }
 
   // This is just used to avoid unnecessary rerendering of resource-heavy webviews 
   @computed get allDisplayedUnordered() {
     const services = this.allServicesRequest.execute().result || [];
-    return this.stores.settings.all.service.showDisabledServices ? services : services.filter(service => service.isEnabled);
+    return this.stores.settings.all.app.showDisabledServices ? services : services.filter(service => service.isEnabled);
   }
 
   @computed get filtered() {
@@ -434,7 +434,7 @@ export default class ServicesStore extends Store {
   }
 
   @action _reorder({ oldIndex, newIndex }) {
-    const showDisabledServices = this.stores.settings.all.service.showDisabledServices;
+    const showDisabledServices = this.stores.settings.all.app.showDisabledServices;
     const oldEnabledSortIndex = showDisabledServices ? oldIndex : this.all.indexOf(this.enabled[oldIndex]);
     const newEnabledSortIndex = showDisabledServices ? newIndex : this.all.indexOf(this.enabled[newIndex]);
 
@@ -554,7 +554,10 @@ export default class ServicesStore extends Store {
 
   _logoutReaction() {
     if (!this.stores.user.isLoggedIn) {
-      this.actions.settings.remove({ key: 'activeService' });
+      this.actions.settings.remove({
+        type: 'service',
+        key: 'activeService',
+      });
       this.allServicesRequest.invalidate().reset();
     }
   }
@@ -562,7 +565,7 @@ export default class ServicesStore extends Store {
   _shareSettingsWithServiceProcess() {
     this.actions.service.sendIPCMessageToAllServices({
       channel: 'settings-update',
-      args: this.stores.settings.all,
+      args: this.stores.settings.all.app,
     });
   }
 

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -86,13 +86,13 @@ export default class ServicesStore extends Store {
   }
 
   @computed get allDisplayed() {
-    return this.stores.settings.all.showDisabledServices ? this.all : this.enabled;
+    return this.stores.settings.all.service.showDisabledServices ? this.all : this.enabled;
   }
 
   // This is just used to avoid unnecessary rerendering of resource-heavy webviews 
   @computed get allDisplayedUnordered() {
     const services = this.allServicesRequest.execute().result || [];
-    return this.stores.settings.all.showDisabledServices ? services : services.filter(service => service.isEnabled);
+    return this.stores.settings.all.service.showDisabledServices ? services : services.filter(service => service.isEnabled);
   }
 
   @computed get filtered() {
@@ -334,7 +334,7 @@ export default class ServicesStore extends Store {
       });
     } else if (channel === 'notification') {
       const options = args[0].options;
-      if (service.recipe.hasNotificationSound || service.isMuted || this.stores.settings.all.isAppMuted) {
+      if (service.recipe.hasNotificationSound || service.isMuted || this.stores.settings.all.app.isAppMuted) {
         Object.assign(options, {
           silent: true,
         });
@@ -434,7 +434,7 @@ export default class ServicesStore extends Store {
   }
 
   @action _reorder({ oldIndex, newIndex }) {
-    const showDisabledServices = this.stores.settings.all.showDisabledServices;
+    const showDisabledServices = this.stores.settings.all.service.showDisabledServices;
     const oldEnabledSortIndex = showDisabledServices ? oldIndex : this.all.indexOf(this.enabled[oldIndex]);
     const newEnabledSortIndex = showDisabledServices ? newIndex : this.all.indexOf(this.enabled[newIndex]);
 
@@ -512,7 +512,8 @@ export default class ServicesStore extends Store {
 
     if (service) {
       this.actions.settings.update({
-        settings: {
+        type: 'service',
+        data: {
           activeService: service.id,
         },
       });
@@ -520,7 +521,7 @@ export default class ServicesStore extends Store {
   }
 
   _mapActiveServiceToServiceModelReaction() {
-    const { activeService } = this.stores.settings.all;
+    const { activeService } = this.stores.settings.all.service;
     if (this.allDisplayed.length) {
       this.allDisplayed.map(service => Object.assign(service, {
         isActive: activeService ? activeService === service.id : this.allDisplayed[0].id === service.id,
@@ -529,7 +530,7 @@ export default class ServicesStore extends Store {
   }
 
   _getUnreadMessageCountReaction() {
-    const showMessageBadgeWhenMuted = this.stores.settings.all.showMessageBadgeWhenMuted;
+    const showMessageBadgeWhenMuted = this.stores.settings.all.app.showMessageBadgeWhenMuted;
     const showMessageBadgesEvenWhenMuted = this.stores.ui.showMessageBadgesEvenWhenMuted;
 
     const unreadDirectMessageCount = this.allDisplayed

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -1,8 +1,5 @@
-// import { remote } from 'electron';
-import { action, computed, observable } from 'mobx';
+import { action, reaction, computed, observable } from 'mobx';
 import { debounce, remove } from 'lodash';
-// import path from 'path';
-// import fs from 'fs-extra';
 
 import Store from './lib/Store';
 import Request from './lib/Request';
@@ -63,11 +60,18 @@ export default class ServicesStore extends Store {
       this._mapActiveServiceToServiceModelReaction.bind(this),
       this._saveActiveService.bind(this),
       this._logoutReaction.bind(this),
-      this._shareSettingsWithServiceProcess.bind(this),
     ]);
 
     // Just bind this
     this._initializeServiceRecipeInWebview.bind(this);
+  }
+
+  setup() {
+    // Single key reactions
+    reaction(
+      () => this.stores.settings.all.app.enableSpellchecking,
+      () => this._shareSettingsWithServiceProcess(),
+    );
   }
 
   @computed get all() {

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -1,4 +1,3 @@
-import { ipcRenderer } from 'electron';
 import { action, computed, observable } from 'mobx';
 import localStorage from 'mobx-localstorage';
 

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -65,11 +65,6 @@ export default class SettingsStore extends Store {
     }
   }
 
-  // Reactions
-  _shareSettingsWithMainProcess() {
-    ipcRenderer.send('settings', this.all);
-  }
-
   // Helper
   _migrate() {
     const legacySettings = localStorage.getItem('app');

--- a/src/stores/UIStore.js
+++ b/src/stores/UIStore.js
@@ -17,7 +17,7 @@ export default class UIStore extends Store {
   @computed get showMessageBadgesEvenWhenMuted() {
     const settings = this.stores.settings.all;
 
-    return (settings.isAppMuted && settings.showMessageBadgeWhenMuted) || !settings.isAppMuted;
+    return (settings.app.isAppMuted && settings.app.showMessageBadgeWhenMuted) || !settings.isAppMuted;
   }
 
   // Actions

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -9,6 +9,8 @@ import Request from './lib/Request';
 import CachedRequest from './lib/CachedRequest';
 import { gaEvent } from '../lib/analytics';
 
+const debug = require('debug')('UserStore');
+
 // TODO: split stores into UserStore and AuthStore
 export default class UserStore extends Store {
   BASE_ROUTE = '/auth';
@@ -67,6 +69,11 @@ export default class UserStore extends Store {
       this._requireAuthenticatedUser,
       this._getUserData.bind(this),
     ]);
+  }
+
+  setup() {
+    // Data migration
+    this._migrateUserLocale();
   }
 
   // Routes
@@ -290,6 +297,19 @@ export default class UserStore extends Store {
     } else {
       this.authToken = null;
       this.id = null;
+    }
+  }
+
+  async _migrateUserLocale() {
+    await this.getUserInfoRequest._promise;
+
+    if (!this.data.locale) {
+      debug('Migrate "locale" to user data');
+      this.actions.user.update({
+        userData: {
+          locale: this.stores.app.locale,
+        },
+      });
     }
   }
 }

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -263,8 +263,10 @@ export default class UserStore extends Store {
 
       // We need to set the beta flag for the SettingsStore
       this.actions.settings.update({
-        settings: {
+        type: 'app',
+        data: {
           beta: data.beta,
+          locale: data.locale,
         },
       });
     }

--- a/src/webview/plugin.js
+++ b/src/webview/plugin.js
@@ -8,6 +8,8 @@ import RecipeWebview from './lib/RecipeWebview';
 import Spellchecker from './spellchecker';
 import './notifications';
 
+const debug = require('debug')('Plugin');
+
 ipcRenderer.on('initializeRecipe', (e, data) => {
   const modulePath = path.join(data.recipe.path, 'webview.js');
   // Delete module from cache
@@ -15,8 +17,9 @@ ipcRenderer.on('initializeRecipe', (e, data) => {
   try {
     // eslint-disable-next-line
     require(modulePath)(new RecipeWebview(), data);
+    debug('Initialize Recipe');
   } catch (err) {
-    console.error(err);
+    debug('Recipe initialization failed', err);
   }
 });
 
@@ -31,6 +34,7 @@ new ContextMenuListener((info) => { // eslint-disable-line
 
 ipcRenderer.on('settings-update', (e, data) => {
   spellchecker.toggleSpellchecker(data.enableSpellchecking);
+  debug('Settings update received', data);
 });
 
 // initSpellche


### PR DESCRIPTION
### Description
To enable certain features like disabling GPU acceleration we need to move certain parts of the app configuration to the main process. 

Additionally to the localStorage stores we are now saving certain app specific configs in settings.json in
- `%APPDATA%\Franz\config` on Windows
- `$XDG_CONFIG_HOME/Franz` or `~/.config/Franz/config` on Linux
- `~/Library/Application Support/Franz/config` on macOS

### Motivation and Context
Ground work for new main-process only features like disable GPU acceleration
