### PR TITLE
Fixed File->Quit button that don't quit the Franz.

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -589,6 +589,9 @@ export default class FranzMenu {
         {
           label: intl.formatMessage(menuItems.quit),
           role: 'quit',
+          click: () => {
+            app.quit();
+          },
         },
       ],
     });


### PR DESCRIPTION
Sience last update "Quit" option under File menu item isn't working.
It's probably because lines 647 - 649 were removed from Menu.js in f720d30.
I did little "undo" - pasted those lines back in place.