### PR TITLE
Remove minimize setting check on close event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ const createWindow = () => {
         mainWindow.hide();
       }
 
-      if (isWindows && settings.get('minimizeToSystemTray')) {
+      if (isWindows) {
         mainWindow.setSkipTaskbar(true);
       }
     } else {


### PR DESCRIPTION
### Description
This change was a simple one-liner, just removed minimizeToSystemTray setting check from condition in close event. It's explained below.

### Motivation and Context
It fixes issues #763 and #1006. Both describes a problem that you can't close a window until minimize to system tray is enabled. Which then, as a setting suggests, you loose a minimize to taskbar function. Therefore, minimization setting should not interfere with closing.

With provided code change, window will close as it should, according to "runInBackground" setting it will stay in system tray or will quit. Minimize function will not interfere with this functionality. When "minimize to system tray" enabled, it will only affect the window minimize function with overriding it to minimize to system tray instead, otherwise minimize function will stay intact.

### How Has This Been Tested?
It was tested on Windows 10 and honestly, there is not much test. Close will close window, minimize will minimize to taskbar or system tray, according to its setting. As described above.

### Screenshots:
Fixed behavior
![franz1](https://user-images.githubusercontent.com/20380121/43045701-a8c9f4a4-8dbd-11e8-87b1-ac5b022f27cf.gif)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
