### PR TITLE
Fixed service shortcut from Ctrl + 10 to Ctrl + 0

### DIFF
--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -159,7 +159,7 @@ class TabItem extends Component {
         })}
         onClick={clickHandler}
         onContextMenu={() => menu.popup(remote.getCurrentWindow())}
-        data-tip={`${service.name} ${shortcutIndex <= 9 ? `(${ctrlKey}+${shortcutIndex})` : ''}`}
+        data-tip={`${service.name} ${shortcutIndex <= 9 ? `(${ctrlKey}+${shortcutIndex})` : shortcutIndex == 10 ? `(${ctrlKey}+0)` : ''}`}
       >
         <img
           src={service.icon}

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -677,7 +677,7 @@ export default class FranzMenu {
     if (this.stores.user.isLoggedIn) {
       return services.map((service, i) => ({
         label: this._getServiceName(service),
-        accelerator: i <= 9 ? `${cmdKey}+${i + 1}` : null,
+        accelerator: i < 9 ? `${cmdKey}+${i + 1}` : i == 10 ? `${cmdKey}+0` : null,
         type: 'radio',
         checked: service.isActive,
         click: () => {


### PR DESCRIPTION
### Description
In the top menu you can see, if you add at least 10 services, a shortcut "Ctrl+10" that is obviously not possible. This update fixes it to a more reasonable Ctrl + 0.

### Motivation and Context
As above.

### How Has This Been Tested?
Here comes the trouble. Unluckily I have problems with yarn on my machine so I was not able to properly test it. Please consider this when trying this fix.

### Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
