### PR TITLE
Lock electron-fetch to stop breakage from version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.2.5",
     "debug-electron": "^0.0.4",
     "du": "^0.1.0",
-    "electron-fetch": "^1.1.0",
+    "electron-fetch": "~1.1.0",
     "electron-react-titlebar": "^0.7.1",
     "electron-spellchecker": "^1.1.2",
     "electron-updater": "^2.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,7 +1959,7 @@ electron-download@^4.0.0:
     semver "^5.3.0"
     sumchecker "^2.0.1"
 
-electron-fetch@^1.1.0:
+electron-fetch@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/electron-fetch/-/electron-fetch-1.1.0.tgz#74b0ea547fe149620d38596a84fb104d34218e31"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
electron-fetch version bump was causing errors when trying to download new service recipes.

### Motivation and Context
This seems to be related to #573, at least the second to last comment is caused by this.

### How Has This Been Tested?
I've been running my fork of Franz with this for almost a month now.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
