### PR TITLE
typo: `dnf-install` has to be `dnf install`

### DIFF
--- a/docs/linux.md
+++ b/docs/linux.md
@@ -7,5 +7,5 @@ $ apt install libx11-dev libxext-dev libxss-dev libxkbfile-dev
 
 ## Fedora
 ```bash
-$ dnf-install libX11-devel libXext-devel libXScrnSaver-devel libxkbfile-devel
+$ dnf install libX11-devel libXext-devel libXScrnSaver-devel libxkbfile-devel
 ```


### PR DESCRIPTION
### Description
There was a typo in the installation instructions for linux. The command `dnf-install` does not exist. `dnf install` without the dash is the right command to use.
