### PR TITLE
Add menu accelerators to cycle through services

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -268,6 +268,8 @@
   "menu.app.unhide": "Unhide",
   "menu.app.quit": "Quit",
   "menu.services.addNewService": "Add New Service...",
+  "menu.services.nextService": "Open Next Service...",
+  "menu.services.prevService": "Open Previous Service...",
   "validation.required": "{field} is required",
   "validation.email": "{field} is not valid",
   "validation.url": "{field} is not a valid URL",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -60,6 +60,8 @@
    "menu.help.tos" : "Termos do Serviço",
    "menu.services" : "Serviços",
    "menu.services.addNewService" : "Adicionar Novo Serviço...",
+   "menu.services.nextService" : "Abrir Próximo Serviço...",
+   "menu.services.prevService" : "Abrir Serviço Anterior...",
    "menu.view" : "Ver",
    "menu.view.enterFullScreen" : "Ativar Modo de Ecrã Completo",
    "menu.view.exitFullScreen" : "Sair do Modo de Ecrã Completo",

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -179,6 +179,14 @@ const menuItems = defineMessages({
     id: 'menu.services.addNewService',
     defaultMessage: '!!!Add New Service...',
   },
+  nextService: {
+    id: 'menu.services.nextService',
+    defaultMessage: '!!!Open Next Service...',
+  },
+  prevService: {
+    id: 'menu.services.prevService',
+    defaultMessage: '!!!Open Previous Service...',
+  },
 });
 
 function getActiveWebview() {
@@ -663,16 +671,35 @@ export default class FranzMenu {
       }, about);
     }
 
-    serviceTpl.unshift({
-      label: intl.formatMessage(menuItems.addNewService),
-      accelerator: `${cmdKey}+N`,
-      click: () => {
-        this.actions.ui.openSettings({ path: 'recipes' });
+    serviceTpl.unshift(
+      {
+        label: intl.formatMessage(menuItems.addNewService),
+        accelerator: `${cmdKey}+N`,
+        click: () => {
+          this.actions.ui.openSettings({ path: 'recipes' });
+        },
+        enabled: this.stores.user.isLoggedIn,
       },
-      enabled: this.stores.user.isLoggedIn,
-    }, {
-      type: 'separator',
-    });
+      {
+        accelerator: isMac ? `${cmdKey}+Option+Down` : `${cmdKey}+PageDown`,
+        label: intl.formatMessage(menuItems.nextService),
+        click: () => {
+          this.actions.service.setActiveNext();
+        },
+        enabled: this.stores.user.isLoggedIn,
+      },
+      {
+        label: intl.formatMessage(menuItems.prevService),
+        accelerator: isMac ? `${cmdKey}+Option+Up` : `${cmdKey}+PageUp`,
+        click: () => {
+          this.actions.service.setActivePrev();
+        },
+        enabled: this.stores.user.isLoggedIn,
+      },
+      {
+        type: 'separator',
+      },
+    );
 
     if (serviceTpl.length > 0) {
       tpl[3].submenu = serviceTpl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR introduces menu accelerators to cycle through services.

### macOs
- Next Service: `Command` + `Option` + `Down`
- Previous Service: `Command` + `Option` + `Up`

### Linux, Windows
- Next Service: `Ctrl` + `Page Down`
- Previous Service: `Ctrl` + `Page Up`

### Motivation and Context
Lack of menu accelerators to cycle through services. Previous shortcuts at [AppStore.js](https://github.com/meetfranz/franz/blob/master/src/stores/AppStore.js#L155) stopped working after commit [d130f26](https://github.com/meetfranz/franz/commit/d130f26) as reported recently on a few issues:

- [1313](https://github.com/meetfranz/franz/issues/1313)
- [1298](https://github.com/meetfranz/franz/issues/1298)
- [1280](https://github.com/meetfranz/franz/issues/1280)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
**DEV MODE**
- macOS Mojave 10.14.4
- Linux Solus 3.99

### Screenshots (if appropriate):
![Screen Shot 2019-03-15 at 18 57 46](https://user-images.githubusercontent.com/9258892/54464299-d9e50280-4754-11e9-9009-cda3fd039f37.png)
![Screen Shot 2019-03-15 at 18 58 15](https://user-images.githubusercontent.com/9258892/54464303-dd788980-4754-11e9-8c23-695c2ce892e8.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
