### PR TITLE
Fix service reordering within workspaces

### DIFF
--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -57,6 +57,10 @@ export default class WorkspacesStore extends FeatureStore {
     return !this.isPremiumUpgradeRequired;
   }
 
+  @computed get isAnyWorkspaceActive() {
+    return !!this.activeWorkspace;
+  }
+
   // ========== PRIVATE PROPERTIES ========= //
 
   _wasDrawerOpenBeforeSettingsRoute = null;
@@ -227,6 +231,14 @@ export default class WorkspacesStore extends FeatureStore {
 
   @action _openWorkspaceSettings = () => {
     this.actions.ui.openSettings({ path: 'workspaces' });
+  };
+
+  @action reorderServicesOfActiveWorkspace = async ({ oldIndex, newIndex }) => {
+    const { activeWorkspace } = this;
+    const { services } = activeWorkspace;
+    // Move services from the old to the new position
+    services.splice(newIndex, 0, services.splice(oldIndex, 1)[0]);
+    await updateWorkspaceRequest.execute(activeWorkspace);
   };
 
   // Reactions

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -517,7 +517,16 @@ export default class ServicesStore extends Store {
     this.actions.ui.toggleServiceUpdatedInfoBar({ visible: false });
   }
 
-  @action _reorder({ oldIndex, newIndex }) {
+  @action _reorder(params) {
+    const { workspaces } = this.stores;
+    if (workspaces.isAnyWorkspaceActive) {
+      workspaces.reorderServicesOfActiveWorkspace(params);
+    } else {
+      this._reorderService(params);
+    }
+  }
+
+  @action _reorderService({ oldIndex, newIndex }) {
     const showDisabledServices = this.stores.settings.all.app.showDisabledServices;
     const oldEnabledSortIndex = showDisabledServices ? oldIndex : this.all.indexOf(this.enabled[oldIndex]);
     const newEnabledSortIndex = showDisabledServices ? newIndex : this.all.indexOf(this.enabled[newIndex]);


### PR DESCRIPTION
This PR fixes a bug when reordering services (drag & drop) within workspaces.