### PR TITLE
Fix/announcement not shown within workspace

### DIFF
--- a/packages/theme/src/themes/dark/index.ts
+++ b/packages/theme/src/themes/dark/index.ts
@@ -113,7 +113,7 @@ export const workspaces = merge({}, defaultStyles.workspaces, {
 });
 
 // Announcements
-export const announcements = merge({}, defaultStyles.workspaces, {
+export const announcements = merge({}, defaultStyles.announcements, {
   spotlight: {
     background: legacyStyles.darkThemeGrayDark,
   },

--- a/src/actions/service.js
+++ b/src/actions/service.js
@@ -4,6 +4,7 @@ import ServiceModel from '../models/Service';
 export default {
   setActive: {
     serviceId: PropTypes.string.isRequired,
+    keepActiveRoute: PropTypes.bool,
   },
   blurActive: {},
   setActiveNext: {},

--- a/src/app.js
+++ b/src/app.js
@@ -43,6 +43,8 @@ import SubscriptionPopupScreen from './containers/subscription/SubscriptionPopup
 import WorkspacesScreen from './features/workspaces/containers/WorkspacesScreen';
 import EditWorkspaceScreen from './features/workspaces/containers/EditWorkspaceScreen';
 import { WORKSPACES_ROUTES } from './features/workspaces';
+import AnnouncementScreen from './features/announcements/components/AnnouncementScreen';
+import { ANNOUNCEMENTS_ROUTES } from './features/announcements';
 
 // Add Polyfills
 smoothScroll.polyfill();
@@ -73,6 +75,7 @@ window.addEventListener('load', () => {
           <I18N>
             <Router history={history}>
               <Route path="/" component={AppLayoutContainer}>
+                <Route path={ANNOUNCEMENTS_ROUTES.TARGET} component={AnnouncementScreen} />
                 <Route path="/settings" component={SettingsWindow}>
                   <IndexRedirect to="/settings/recipes" />
                   <Route path="/settings/recipes" component={RecipesScreen} />

--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -14,7 +14,6 @@ import ErrorBoundary from '../util/ErrorBoundary';
 // import globalMessages from '../../i18n/globalMessages';
 
 import { isWindows } from '../../environment';
-import AnnouncementScreen from '../../features/announcements/components/AnnouncementScreen';
 import WorkspaceSwitchingIndicator from '../../features/workspaces/components/WorkspaceSwitchingIndicator';
 import { workspaceStore } from '../../features/workspaces';
 import { announcementActions } from '../../features/announcements/actions';

--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -83,7 +83,6 @@ class AppLayout extends Component {
     areRequiredRequestsLoading: PropTypes.bool.isRequired,
     darkMode: PropTypes.bool.isRequired,
     isDelayAppScreenVisible: PropTypes.bool.isRequired,
-    isAnnouncementVisible: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -117,7 +116,6 @@ class AppLayout extends Component {
       areRequiredRequestsLoading,
       darkMode,
       isDelayAppScreenVisible,
-      isAnnouncementVisible,
     } = this.props;
 
     const { intl } = this.context;
@@ -197,12 +195,11 @@ class AppLayout extends Component {
                 {isDelayAppScreenVisible && (<DelayApp />)}
                 <BasicAuth />
                 <ShareFranz />
-                {isAnnouncementVisible && (<AnnouncementScreen />)}
                 {services}
+                {children}
               </div>
             </div>
           </div>
-          {children}
         </div>
       </ErrorBoundary>
     );

--- a/src/containers/layout/AppLayoutContainer.js
+++ b/src/containers/layout/AppLayoutContainer.js
@@ -151,7 +151,6 @@ export default @inject('stores', 'actions') @observer class AppLayoutContainer e
           areRequiredRequestsLoading={requests.areRequiredRequestsLoading}
           darkMode={settings.all.app.darkMode}
           isDelayAppScreenVisible={delayAppState.isDelayAppScreenVisible}
-          isAnnouncementVisible={announcementsStore.isAnnouncementVisible}
         >
           {React.Children.count(children) > 0 ? children : null}
         </AppLayout>

--- a/src/containers/layout/AppLayoutContainer.js
+++ b/src/containers/layout/AppLayoutContainer.js
@@ -23,7 +23,6 @@ import { state as delayAppState } from '../../features/delayApp';
 import { workspaceActions } from '../../features/workspaces/actions';
 import WorkspaceDrawer from '../../features/workspaces/components/WorkspaceDrawer';
 import { workspaceStore } from '../../features/workspaces';
-import { announcementsStore } from '../../features/announcements';
 
 export default @inject('stores', 'actions') @observer class AppLayoutContainer extends Component {
   static defaultProps = {

--- a/src/features/announcements/components/AnnouncementScreen.js
+++ b/src/features/announcements/components/AnnouncementScreen.js
@@ -268,7 +268,7 @@ class AnnouncementScreen extends Component {
           <div className={classes.changelog}>
             <h1 className={classes.headline}>
               {intl.formatMessage(messages.headline, {
-                version: announcementsStore.currentVersion,
+                version: announcementsStore.targetVersion,
               })}
             </h1>
             <div

--- a/src/features/announcements/index.js
+++ b/src/features/announcements/index.js
@@ -7,6 +7,10 @@ export const GA_CATEGORY_ANNOUNCEMENTS = 'Announcements';
 
 export const announcementsStore = new AnnouncementsStore();
 
+export const ANNOUNCEMENTS_ROUTES = {
+  TARGET: '/announcements/:id',
+};
+
 export default function initAnnouncements(stores, actions) {
   // const { features } = stores;
 

--- a/src/features/announcements/store.js
+++ b/src/features/announcements/store.js
@@ -2,7 +2,6 @@ import {
   action,
   computed,
   observable,
-  reaction,
 } from 'mobx';
 import semver from 'semver';
 import localStorage from 'mobx-localstorage';

--- a/src/features/announcements/store.js
+++ b/src/features/announcements/store.js
@@ -122,12 +122,7 @@ export class AnnouncementsStore extends FeatureStore {
     const targetVersion = this.targetVersion || this.currentVersion;
     if (!targetVersion) return;
     getChangelogRequest.execute(targetVersion);
-    // We only fetch announcements for current / older versions
-    if (targetVersion <= this.currentVersion) {
-      getAnnouncementRequest.execute(targetVersion);
-    } else {
-      getAnnouncementRequest.reset();
-    }
+    getAnnouncementRequest.execute(targetVersion);
   };
 
   _showAnnouncementOnRouteMatch = () => {

--- a/src/features/announcements/store.js
+++ b/src/features/announcements/store.js
@@ -35,7 +35,6 @@ export class AnnouncementsStore extends FeatureStore {
   @computed get areNewsAvailable() {
     const isChangelogAvailable = getChangelogRequest.wasExecuted && !!this.changelog;
     const isAnnouncementAvailable = getAnnouncementRequest.wasExecuted && !!this.announcement;
-    console.log(isChangelogAvailable, isAnnouncementAvailable);
     return isChangelogAvailable || isAnnouncementAvailable;
   }
 

--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -255,13 +255,15 @@ export default class WorkspacesStore extends FeatureStore {
   _setActiveServiceOnWorkspaceSwitchReaction = () => {
     if (!this.isFeatureActive) return;
     if (this.activeWorkspace) {
-      const services = this.stores.services.allDisplayed;
-      const activeService = services.find(s => s.isActive);
+      const activeService = this.stores.services.active;
       const workspaceServices = this.getWorkspaceServices(this.activeWorkspace);
       if (workspaceServices.length <= 0) return;
       const isActiveServiceInWorkspace = workspaceServices.includes(activeService);
       if (!isActiveServiceInWorkspace) {
-        this.actions.service.setActive({ serviceId: workspaceServices[0].id });
+        this.actions.service.setActive({
+          serviceId: workspaceServices[0].id,
+          keepActiveRoute: true,
+        });
       }
     }
   };

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -625,78 +625,78 @@
         "defaultMessage": "!!!Your services have been updated.",
         "end": {
           "column": 3,
-          "line": 30
+          "line": 29
         },
         "file": "src/components/layout/AppLayout.js",
         "id": "infobar.servicesUpdated",
         "start": {
           "column": 19,
-          "line": 27
+          "line": 26
         }
       },
       {
         "defaultMessage": "!!!A new update for Franz is available.",
         "end": {
           "column": 3,
-          "line": 34
+          "line": 33
         },
         "file": "src/components/layout/AppLayout.js",
         "id": "infobar.updateAvailable",
         "start": {
           "column": 19,
-          "line": 31
+          "line": 30
         }
       },
       {
         "defaultMessage": "!!!Reload services",
         "end": {
           "column": 3,
-          "line": 38
+          "line": 37
         },
         "file": "src/components/layout/AppLayout.js",
         "id": "infobar.buttonReloadServices",
         "start": {
           "column": 24,
-          "line": 35
+          "line": 34
         }
       },
       {
         "defaultMessage": "!!!Changelog",
         "end": {
           "column": 3,
-          "line": 42
+          "line": 41
         },
         "file": "src/components/layout/AppLayout.js",
         "id": "infobar.buttonChangelog",
         "start": {
           "column": 13,
-          "line": 39
+          "line": 38
         }
       },
       {
         "defaultMessage": "!!!Restart & install update",
         "end": {
           "column": 3,
-          "line": 46
+          "line": 45
         },
         "file": "src/components/layout/AppLayout.js",
         "id": "infobar.buttonInstallUpdate",
         "start": {
           "column": 23,
-          "line": 43
+          "line": 42
         }
       },
       {
         "defaultMessage": "!!!Could not load services and user information",
         "end": {
           "column": 3,
-          "line": 50
+          "line": 49
         },
         "file": "src/components/layout/AppLayout.js",
         "id": "infobar.requiredRequestsFailed",
         "start": {
           "column": 26,
-          "line": 47
+          "line": 46
         }
       }
     ],

--- a/src/i18n/messages/src/components/layout/AppLayout.json
+++ b/src/i18n/messages/src/components/layout/AppLayout.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Your services have been updated.",
     "file": "src/components/layout/AppLayout.js",
     "start": {
-      "line": 27,
+      "line": 26,
       "column": 19
     },
     "end": {
-      "line": 30,
+      "line": 29,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!A new update for Franz is available.",
     "file": "src/components/layout/AppLayout.js",
     "start": {
-      "line": 31,
+      "line": 30,
       "column": 19
     },
     "end": {
-      "line": 34,
+      "line": 33,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Reload services",
     "file": "src/components/layout/AppLayout.js",
     "start": {
-      "line": 35,
+      "line": 34,
       "column": 24
     },
     "end": {
-      "line": 38,
+      "line": 37,
       "column": 3
     }
   },
@@ -43,11 +43,11 @@
     "defaultMessage": "!!!Changelog",
     "file": "src/components/layout/AppLayout.js",
     "start": {
-      "line": 39,
+      "line": 38,
       "column": 13
     },
     "end": {
-      "line": 42,
+      "line": 41,
       "column": 3
     }
   },
@@ -56,11 +56,11 @@
     "defaultMessage": "!!!Restart & install update",
     "file": "src/components/layout/AppLayout.js",
     "start": {
-      "line": 43,
+      "line": 42,
       "column": 23
     },
     "end": {
-      "line": 46,
+      "line": 45,
       "column": 3
     }
   },
@@ -69,11 +69,11 @@
     "defaultMessage": "!!!Could not load services and user information",
     "file": "src/components/layout/AppLayout.js",
     "start": {
-      "line": 47,
+      "line": 46,
       "column": 26
     },
     "end": {
-      "line": 50,
+      "line": 49,
       "column": 3
     }
   }

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -291,7 +291,8 @@ export default class ServicesStore extends Store {
     gaEvent('Service', 'clear cache');
   }
 
-  @action _setActive({ serviceId }) {
+  @action _setActive({ serviceId, keepActiveRoute }) {
+    if (!keepActiveRoute) this.stores.router.push('/');
     const service = this.one(serviceId);
 
     this.all.forEach((s, index) => {


### PR DESCRIPTION
This PR fixes a bug with showing announcements to users that upgrade Franz.
The problem was that announcement rendering was tightly coupled to the active service which introduced all kinds of edge cases …

This was resolved by refactoring the announcements screen to be a dedicated route which can now be triggered over the router and is much more solid.