### PR TITLE
support multilingual announcements

### DIFF
--- a/src/features/announcements/store.js
+++ b/src/features/announcements/store.js
@@ -29,7 +29,15 @@ export class AnnouncementsStore extends FeatureStore {
   }
 
   @computed get announcement() {
-    return getAnnouncementRequest.result;
+    if (!this.stores || !getAnnouncementRequest.result) return null;
+    const { locale, defaultLocale } = this.stores.app;
+    const announcement = getAnnouncementRequest.result;
+    // User locale
+    if (announcement[locale]) return announcement[locale];
+    // Default locale
+    if (announcement[defaultLocale]) return announcement[defaultLocale];
+    // No locales specified
+    return announcement;
   }
 
   @computed get areNewsAvailable() {
@@ -121,8 +129,8 @@ export class AnnouncementsStore extends FeatureStore {
   _fetchAnnouncements = () => {
     const targetVersion = this.targetVersion || this.currentVersion;
     if (!targetVersion) return;
-    getChangelogRequest.execute(targetVersion);
-    getAnnouncementRequest.execute(targetVersion);
+    getChangelogRequest.reset().execute(targetVersion);
+    getAnnouncementRequest.reset().execute(targetVersion);
   };
 
   _showAnnouncementOnRouteMatch = () => {


### PR DESCRIPTION
This PR adds support for multilingual announcements with the following logic:
1. if the announcement json includes the users locale as root key -> take that
2. if there is the default locale defined -> take that
3. If no default locale, treat the announcement as not multilingual and pick root