### PR TITLE
logout user when access token is invalid

### DIFF
--- a/src/stores/GlobalErrorStore.js
+++ b/src/stores/GlobalErrorStore.js
@@ -18,8 +18,11 @@ export default class GlobalErrorStore extends Store {
       this.error = request.error;
 
       if (request.error.json) {
-        this.response = await request.error.json();
-
+        try {
+          this.response = await request.error.json();
+        } catch (error) {
+          this.response = {};
+        }
         if (this.error.status === 401) {
           this.actions.user.logout({ serverLogout: true });
         }

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -329,8 +329,7 @@ export default class UserStore extends Store {
         authToken,
       });
     } catch (err) {
-      console.error('AccessToken Invalid');
-
+      this._logout();
       return false;
     }
   }


### PR DESCRIPTION
This PR fixes a bug so that the user is correctly logged out when the auth token is invalid. Also adds a catch for invalid json responses in the global error store.