### PR TITLE
Fix invalid services references in workspaces locally

### DIFF
--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -312,17 +312,13 @@ export default class WorkspacesStore extends FeatureStore {
 
   _cleanupInvalidServiceReferences = () => {
     const { services } = this.stores;
-    let invalidServiceReferencesExist = false;
     this.workspaces.forEach((workspace) => {
       workspace.services.forEach((serviceId) => {
-        if (!services.one(serviceId)) {
-          invalidServiceReferencesExist = true;
+        if (services.allServicesRequest.wasExecuted && !services.one(serviceId)) {
+          workspace.services.remove(serviceId);
         }
       });
     });
-    if (invalidServiceReferencesExist) {
-      getUserWorkspacesRequest.execute();
-    }
   };
 
   _stopPremiumActionsAndReactions = () => {

--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -312,9 +312,12 @@ export default class WorkspacesStore extends FeatureStore {
 
   _cleanupInvalidServiceReferences = () => {
     const { services } = this.stores;
+    const { allServicesRequest } = services;
+    const servicesHaveBeenLoaded = allServicesRequest.wasExecuted && !allServicesRequest.isError;
+    // Loop through all workspaces and remove invalid service ids (locally)
     this.workspaces.forEach((workspace) => {
       workspace.services.forEach((serviceId) => {
-        if (services.allServicesRequest.wasExecuted && !services.one(serviceId)) {
+        if (servicesHaveBeenLoaded && !services.one(serviceId)) {
           workspace.services.remove(serviceId);
         }
       });


### PR DESCRIPTION
This PR fixes a bug that happens when there are invalid service references in a workspace `services` array. The fix simply fixes the problem locally by removing the invalid entry after checking that the services have been loaded.
