### PR TITLE
Add option to keep all workspaces loaded

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -162,6 +162,7 @@ export default @observer class EditSettingsForm extends Component {
             {process.platform === 'win32' && (
               <Toggle field={form.$('minimizeToSystemTray')} />
             )}
+            <Toggle field={form.$('keepAllWorkspacesLoaded')} />
 
             {/* Appearance */}
             <h2 id="apperance">{intl.formatMessage(messages.headlineAppearance)}</h2>

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ export const DEFAULT_APP_SETTINGS = {
   runInBackground: true,
   enableSystemTray: true,
   minimizeToSystemTray: false,
+  keepAllWorkspacesLoaded: false,
   showDisabledServices: true,
   showMessageBadgeWhenMuted: true,
   enableSpellchecking: true,

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -39,6 +39,10 @@ const messages = defineMessages({
     id: 'settings.app.form.minimizeToSystemTray',
     defaultMessage: '!!!Minimize Franz to system tray',
   },
+  keepAllWorkspacesLoaded: {
+    id: 'settings.app.form.keepAllWorkspacesLoaded',
+    defaultMessage: '!!!Keep all workspaces loaded',
+  },
   language: {
     id: 'settings.app.form.language',
     defaultMessage: '!!!Language',
@@ -88,6 +92,7 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
         runInBackground: settingsData.runInBackground,
         enableSystemTray: settingsData.enableSystemTray,
         minimizeToSystemTray: settingsData.minimizeToSystemTray,
+        keepAllWorkspacesLoaded: settingsData.keepAllWorkspacesLoaded,
         enableGPUAcceleration: settingsData.enableGPUAcceleration,
         showDisabledServices: settingsData.showDisabledServices,
         darkMode: settingsData.darkMode,
@@ -141,6 +146,11 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           label: intl.formatMessage(messages.enableSystemTray),
           value: settings.all.app.enableSystemTray,
           default: DEFAULT_APP_SETTINGS.enableSystemTray,
+        },
+        keepAllWorkspacesLoaded: {
+          label: intl.formatMessage(messages.keepAllWorkspacesLoaded),
+          value: settings.all.app.keepAllWorkspacesLoaded,
+          default: DEFAULT_APP_SETTINGS.keepAllWorkspacesLoaded,
         },
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -2991,94 +2991,107 @@
         }
       },
       {
-        "defaultMessage": "!!!Language",
+        "defaultMessage": "!!!Keep all workspaces loaded",
         "end": {
           "column": 3,
           "line": 45
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.language",
+        "id": "settings.app.form.keepAllWorkspacesLoaded",
         "start": {
-          "column": 12,
+          "column": 27,
           "line": 42
         }
       },
       {
-        "defaultMessage": "!!!Dark Mode",
+        "defaultMessage": "!!!Language",
         "end": {
           "column": 3,
           "line": 49
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.darkMode",
+        "id": "settings.app.form.language",
         "start": {
           "column": 12,
           "line": 46
         }
       },
       {
-        "defaultMessage": "!!!Display disabled services tabs",
+        "defaultMessage": "!!!Dark Mode",
         "end": {
           "column": 3,
           "line": 53
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.darkMode",
+        "start": {
+          "column": 12,
+          "line": 50
+        }
+      },
+      {
+        "defaultMessage": "!!!Display disabled services tabs",
+        "end": {
+          "column": 3,
+          "line": 57
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showDisabledServices",
         "start": {
           "column": 24,
-          "line": 50
+          "line": 54
         }
       },
       {
         "defaultMessage": "!!!Show unread message badge when notifications are disabled",
         "end": {
           "column": 3,
-          "line": 57
+          "line": 61
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showMessagesBadgesWhenMuted",
         "start": {
           "column": 29,
-          "line": 54
+          "line": 58
         }
       },
       {
         "defaultMessage": "!!!Enable spell checking",
         "end": {
           "column": 3,
-          "line": 61
+          "line": 65
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableSpellchecking",
         "start": {
           "column": 23,
-          "line": 58
+          "line": 62
         }
       },
       {
         "defaultMessage": "!!!Enable GPU Acceleration",
         "end": {
           "column": 3,
-          "line": 65
+          "line": 69
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableGPUAcceleration",
         "start": {
           "column": 25,
-          "line": 62
+          "line": 66
         }
       },
       {
         "defaultMessage": "!!!Include beta versions",
         "end": {
           "column": 3,
-          "line": 69
+          "line": 73
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.beta",
         "start": {
           "column": 8,
-          "line": 66
+          "line": 70
         }
       }
     ],

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -154,6 +154,7 @@
   "settings.app.form.enableGPUAcceleration": "Enable GPU Acceleration",
   "settings.app.form.enableSpellchecking": "Enable spell checking",
   "settings.app.form.enableSystemTray": "Show Franz in system tray",
+  "settings.app.form.keepAllWorkspacesLoaded": "Keep all workspaces loaded",
   "settings.app.form.language": "Language",
   "settings.app.form.minimizeToSystemTray": "Minimize Franz to system tray",
   "settings.app.form.runInBackground": "Keep Franz in background when closing the window",

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -65,12 +65,12 @@
     }
   },
   {
-    "id": "settings.app.form.language",
-    "defaultMessage": "!!!Language",
+    "id": "settings.app.form.keepAllWorkspacesLoaded",
+    "defaultMessage": "!!!Keep all workspaces loaded",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 42,
-      "column": 12
+      "column": 27
     },
     "end": {
       "line": 45,
@@ -78,8 +78,8 @@
     }
   },
   {
-    "id": "settings.app.form.darkMode",
-    "defaultMessage": "!!!Dark Mode",
+    "id": "settings.app.form.language",
+    "defaultMessage": "!!!Language",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 46,
@@ -91,15 +91,28 @@
     }
   },
   {
+    "id": "settings.app.form.darkMode",
+    "defaultMessage": "!!!Dark Mode",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 50,
+      "column": 12
+    },
+    "end": {
+      "line": 53,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.showDisabledServices",
     "defaultMessage": "!!!Display disabled services tabs",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 50,
+      "line": 54,
       "column": 24
     },
     "end": {
-      "line": 53,
+      "line": 57,
       "column": 3
     }
   },
@@ -108,11 +121,11 @@
     "defaultMessage": "!!!Show unread message badge when notifications are disabled",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 54,
+      "line": 58,
       "column": 29
     },
     "end": {
-      "line": 57,
+      "line": 61,
       "column": 3
     }
   },
@@ -121,11 +134,11 @@
     "defaultMessage": "!!!Enable spell checking",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 58,
+      "line": 62,
       "column": 23
     },
     "end": {
-      "line": 61,
+      "line": 65,
       "column": 3
     }
   },
@@ -134,11 +147,11 @@
     "defaultMessage": "!!!Enable GPU Acceleration",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 62,
+      "line": 66,
       "column": 25
     },
     "end": {
-      "line": 65,
+      "line": 69,
       "column": 3
     }
   },
@@ -147,11 +160,11 @@
     "defaultMessage": "!!!Include beta versions",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 66,
+      "line": 70,
       "column": 8
     },
     "end": {
-      "line": 69,
+      "line": 73,
       "column": 3
     }
   }

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -115,10 +115,10 @@ export default class ServicesStore extends Store {
 
   // This is just used to avoid unnecessary rerendering of resource-heavy webviews
   @computed get allDisplayedUnordered() {
-    const { showDisabledServices } = this.stores.settings.all.app;
+    const { showDisabledServices, keepAllWorkspacesLoaded } = this.stores.settings.all.app;
     const services = this.allServicesRequest.execute().result || [];
     const filteredServices = showDisabledServices ? services : services.filter(service => service.isEnabled);
-    return workspaceStore.filterServicesByActiveWorkspace(filteredServices);
+    return keepAllWorkspacesLoaded ? filteredServices : workspaceStore.filterServicesByActiveWorkspace(filteredServices);
   }
 
   @computed get filtered() {


### PR DESCRIPTION
Implements #1414, which adds the ability to keep all services in all workspaces loaded. This will result in receiving notifications for all workspaces and the ability to switch fast between workspaces.

A new setting is introduced to facility this feature. Defaults to false.

### How Has This Been Tested?
Has been tested. Ubuntu 16.04 running the described environment in the Developers guide. I tested the changes.

Only downside is that I had to force myself premium member, because the payment flow didn't seem to work properly in the test environment (I guess the webhook back to the infra failed).

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/864520/59963017-7d307b00-94ed-11e9-9b00-6c8c54f1ccf3.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
