### PR TITLE
Fix Chinese translation of free

### DIFF
--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -297,7 +297,7 @@
    "subscription.includedFeatures" : "Franz 高級支援帳戶包含",
    "subscription.paymentSessionError" : "無法初始化付款表單",
    "subscription.submit.label" : "我想支持 Franz 開發",
-   "subscription.type.free" : "自由",
+   "subscription.type.free" : "免費",
    "subscription.type.month" : "月",
    "subscription.type.year" : "年",
    "subscriptionPopup.buttonCancel" : "取消",


### PR DESCRIPTION
Fix Chinese translation of free from "自由" to "免費"

### Description
"自由" means freedom while what is intended here is "免費" as in free lunch.

### Motivation and Context
The existing translation is wrong.

### How Has This Been Tested?
I'm a native Chinese speaker.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
