### PR TITLE
fix reactions and workspace cleanup logic

### DIFF
--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -79,7 +79,7 @@ export default class WorkspacesStore extends FeatureStore {
 
   // ========== PUBLIC API ========= //
 
-  start(stores, actions) {
+  @action start(stores, actions) {
     debug('WorkspacesStore::start');
     this.stores = stores;
     this.actions = actions;
@@ -104,7 +104,7 @@ export default class WorkspacesStore extends FeatureStore {
     // REACTIONS
 
     this._freeUserReactions = createReactions([
-      this._stopPremiumActionsAndReactions,
+      this._disablePremiumFeatures,
       this._openDrawerWithSettingsReaction,
       this._setFeatureEnabledReaction,
       this._setIsPremiumFeatureReaction,
@@ -123,15 +123,19 @@ export default class WorkspacesStore extends FeatureStore {
     this.isFeatureActive = true;
   }
 
-  stop() {
-    super.stop();
-    debug('WorkspacesStore::stop');
-    this.isFeatureActive = false;
+  @action reset() {
     this.activeWorkspace = null;
     this.nextWorkspace = null;
     this.workspaceBeingEdited = null;
     this.isSwitchingWorkspace = false;
     this.isWorkspaceDrawerOpen = false;
+  }
+
+  @action stop() {
+    super.stop();
+    debug('WorkspacesStore::stop');
+    this.reset();
+    this.isFeatureActive = false;
   }
 
   filterServicesByActiveWorkspace = (services) => {
@@ -281,6 +285,7 @@ export default class WorkspacesStore extends FeatureStore {
   };
 
   _activateLastUsedWorkspaceReaction = () => {
+    debug('_activateLastUsedWorkspaceReaction');
     if (!this.activeWorkspace && this.userHasWorkspaces) {
       const { lastActiveWorkspace } = this.settings;
       if (lastActiveWorkspace) {
@@ -324,10 +329,12 @@ export default class WorkspacesStore extends FeatureStore {
     });
   };
 
-  _stopPremiumActionsAndReactions = () => {
+  _disablePremiumFeatures = () => {
     if (!this.isUserAllowedToUseFeature) {
+      debug('_disablePremiumFeatures');
       this._stopActions(this._premiumUserActions);
       this._stopReactions(this._premiumUserReactions);
+      this.reset();
     } else {
       this._startActions(this._premiumUserActions);
       this._startReactions(this._premiumUserReactions);

--- a/src/stores/lib/Reaction.js
+++ b/src/stores/lib/Reaction.js
@@ -13,15 +13,15 @@ export default class Reaction {
 
   start() {
     if (!this.isRunning) {
-      this.dispose = autorun(() => this.reaction());
-      this.isActive = true;
+      this.dispose = autorun(this.reaction);
+      this.isRunning = true;
     }
   }
 
   stop() {
     if (this.isRunning) {
       this.dispose();
-      this.isActive = false;
+      this.isRunning = false;
     }
   }
 }


### PR DESCRIPTION
This PR fixes a bug where the workspaces logic was not properly cleaned-up when a user downgraded his account to free while having an active workspace.