### PR TITLE
Fix bug for notification when `options.icon` is undefined

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -189,7 +189,7 @@ export default class AppStore extends Store {
     if (this.stores.settings.all.app.isAppMuted) return;
 
     // TODO: is there a simple way to use blobs for notifications without storing them on disk?
-    if (options.icon.startsWith('blob:')) {
+    if (options.icon && options.icon.startsWith('blob:')) {
       delete options.icon;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR includes fixing a bug for notification is not working.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If `options.icon` is undefined, notify action in `src/stores/AppStore.js` throw an error with "Cannot read property 'startsWith' of undefined". Therefore notification not work.

It related to the #1545 issue and so on.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on Mac with Slack.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
