### PR TITLE
Add tooltip with shortcuts in Workspace Drawer

### DIFF
--- a/src/features/workspaces/components/WorkspaceDrawer.js
+++ b/src/features/workspaces/components/WorkspaceDrawer.js
@@ -204,8 +204,9 @@ class WorkspaceDrawer extends Component {
               }}
               services={getServicesForWorkspace(null)}
               isActive={actualWorkspace == null}
+              shortcutIndex={0}
             />
-            {workspaces.map(workspace => (
+            {workspaces.map((workspace, index) => (
               <WorkspaceDrawerItem
                 key={workspace.id}
                 name={workspace.name}
@@ -218,6 +219,7 @@ class WorkspaceDrawer extends Component {
                 }}
                 onContextMenuEditClick={() => workspaceActions.edit({ workspace })}
                 services={getServicesForWorkspace(workspace)}
+                shortcutIndex={index + 1}
               />
             ))}
             <div

--- a/src/features/workspaces/components/WorkspaceDrawerItem.js
+++ b/src/features/workspaces/components/WorkspaceDrawerItem.js
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react';
 import injectSheet from 'react-jss';
 import classnames from 'classnames';
 import { defineMessages, intlShape } from 'react-intl';
+import { ctrlKey } from '../../../environment';
 
 const { Menu } = remote;
 
@@ -69,6 +70,7 @@ class WorkspaceDrawerItem extends Component {
     onClick: PropTypes.func.isRequired,
     services: PropTypes.arrayOf(PropTypes.string).isRequired,
     onContextMenuEditClick: PropTypes.func,
+    shortcutIndex: PropTypes.number.isRequired,
   };
 
   static defaultProps = {
@@ -87,6 +89,7 @@ class WorkspaceDrawerItem extends Component {
       onClick,
       onContextMenuEditClick,
       services,
+      shortcutIndex
     } = this.props;
     const { intl } = this.context;
 
@@ -112,6 +115,7 @@ class WorkspaceDrawerItem extends Component {
         onContextMenu={() => (
           onContextMenuEditClick && contextMenu.popup(remote.getCurrentWindow())
         )}
+        data-tip={`${shortcutIndex <= 9 ? `(${ctrlKey}+Alt+${shortcutIndex})` : ''}`}
       >
         <span
           className={classnames([

--- a/src/features/workspaces/components/WorkspaceDrawerItem.js
+++ b/src/features/workspaces/components/WorkspaceDrawerItem.js
@@ -89,7 +89,7 @@ class WorkspaceDrawerItem extends Component {
       onClick,
       onContextMenuEditClick,
       services,
-      shortcutIndex
+      shortcutIndex,
     } = this.props;
     const { intl } = this.context;
 


### PR DESCRIPTION
This PR is in reference to https://github.com/meetfranz/franz/issues/1569 
There exist keyboard shortcuts to switch between Workspaces but they are not highlighted

### Description
This adds tooltips to WorkspaceDrawerItems to highlight their keyboard shortcuts

### Motivation and Context
This is mainly a discovery issue. I opened an issue earlier regarding missing shortcuts. I spent some time trying to figure out the code in order to add the shortcuts myself and found that they already exist. 
Reference: https://github.com/meetfranz/franz/issues/1569 

### How Has This Been Tested?
Ran a build locally on macOS

### Screenshots (if appropriate):
![Screenshot 2019-09-23 at 10 32 46 PM](https://user-images.githubusercontent.com/4283218/65446893-f922c200-de52-11e9-9cf2-27a6b687d0ac.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<del>Could not run lint, facing issues. Although I am pretty sure that this is not going to be an issue for the change</del>

- [x] My code follows the code style of this project (run `$ yarn lint`).
