### PR TITLE
Clear confetti timeout on component unmount

### DIFF
--- a/src/components/services/content/Services.js
+++ b/src/components/services/content/Services.js
@@ -56,14 +56,22 @@ export default @observer @injectSheet(styles) class Services extends Component {
 
   state = {
     showConfetti: true,
-  }
+  };
+
+  _confettiTimeout = null;
 
   componentDidMount() {
-    window.setTimeout(() => {
+    this._confettiTimeout = window.setTimeout(() => {
       this.setState({
         showConfetti: false,
       });
     }, ms('8s'));
+  }
+
+  componentWillUnmount() {
+    if (this._confettiTimeout) {
+      clearTimeout(this._confettiTimeout);
+    }
   }
 
   render() {


### PR DESCRIPTION
This PR fixes a small issue with the confetti timeout if the component is unmounted and the timer is not cleared.