### PR TITLE
Fix/only load workspace related services

### DIFF
--- a/src/components/services/content/ServiceWebview.js
+++ b/src/components/services/content/ServiceWebview.js
@@ -37,7 +37,9 @@ class ServiceWebview extends Component {
       <ElectronWebView
         ref={(webview) => {
           this.webview = webview;
-          webview.view.addEventListener('did-stop-loading', this.refocusWebview);
+          if (webview && webview.view) {
+            webview.view.addEventListener('did-stop-loading', this.refocusWebview);
+          }
         }}
         autosize
         src={service.url}

--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -149,7 +149,6 @@ export default class WorkspacesStore extends FeatureStore {
       if (!getUserWorkspacesRequest.wasExecuted || getUserWorkspacesRequest.isExecutingFirstTime) {
         // If so, do not show any services to avoid loading all of them unfiltered
         // and then having the filter flashing in (which is ugly and slow).
-        console.log('return', []);
         return [];
       }
     }

--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -141,8 +141,17 @@ export default class WorkspacesStore extends FeatureStore {
 
   filterServicesByActiveWorkspace = (services) => {
     const { activeWorkspace, isFeatureActive } = this;
-    if (isFeatureActive && activeWorkspace) {
-      return this.getWorkspaceServices(activeWorkspace);
+    if (isFeatureActive) {
+      if (activeWorkspace) {
+        return this.getWorkspaceServices(activeWorkspace);
+      }
+      // There is no active workspace yet but we might be still loading them
+      if (!getUserWorkspacesRequest.wasExecuted || getUserWorkspacesRequest.isExecutingFirstTime) {
+        // If so, do not show any services to avoid loading all of them unfiltered
+        // and then having the filter flashing in (which is ugly and slow).
+        console.log('return', []);
+        return [];
+      }
     }
     return services;
   };


### PR DESCRIPTION
This PR fixes a performance and ux issue with loading all services (reproduce by reloading Franz and watch the sidebar -> there is a short flash of all services) before the workspaces have been determined (and thus unnecessarily using a lot of system resources for a short amount of time). 

With this change the loading of services is delayed until the workspaces requests was executed.