### PR TITLE
Fix disable spell checker method for Electron 6

### DIFF
--- a/src/webview/spellchecker.js
+++ b/src/webview/spellchecker.js
@@ -96,7 +96,7 @@ export function isEnabled() {
 
 export function disable() {
   if (isEnabled()) {
-    webFrame.setSpellCheckProvider(currentDict, true, { spellCheck: () => true });
+    webFrame.setSpellCheckProvider(currentDict, { spellCheck: () => true });
     _isEnabled = false;
     currentDict = null;
   }


### PR DESCRIPTION
While Electron <6 still [required a second "autoCorrectWord" argument](https://github.com/electron/electron/blob/v3.1.0/docs/api/web-frame.md#webframesetspellcheckproviderlanguage-autocorrectword-provider) for `webFrame.setSpellCheckProvider`, Electron 6 [no longer needs this argument](https://electronjs.org/docs/api/web-frame#webframesetspellcheckproviderlanguage-provider). 
Because of this, Franz's service webview will throw an error when trying to disable the Spellchecker.

![Screenshot](https://user-images.githubusercontent.com/10333196/67040635-2a29a600-f124-11e9-90f2-ae32261fc588.png)

This PR is a simple fix, removing the second argument.

### How Has This Been Tested?
- Run Franz locally and test to disable Spellchecker

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
