### PR TITLE
Fix zoom not working

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -340,10 +340,10 @@ const _templateFactory = intl => [
         accelerator: 'Cmd+plus',
         click() {
           const activeService = getActiveWebview();
-          activeService.getZoomLevel((level) => {
-            // level 9 =~ +300% and setZoomLevel wouldnt zoom in further
-            if (level < 9) activeService.setZoomLevel(level + 1);
-          });
+          const level = activeService.getZoomLevel();
+
+          // level 9 =~ +300% and setZoomLevel wouldnt zoom in further
+          if (level < 9) activeService.setZoomLevel(level + 1);
         },
       },
       {
@@ -351,10 +351,10 @@ const _templateFactory = intl => [
         accelerator: 'Cmd+-',
         click() {
           const activeService = getActiveWebview();
-          activeService.getZoomLevel((level) => {
-            // level -9 =~ -50% and setZoomLevel wouldnt zoom out further
-            if (level > -9) activeService.setZoomLevel(level - 1);
-          });
+          const level = activeService.getZoomLevel();
+
+          // level -9 =~ -50% and setZoomLevel wouldnt zoom out further
+          if (level > -9) activeService.setZoomLevel(level - 1);
         },
       },
       {
@@ -515,10 +515,10 @@ const _titleBarTemplateFactory = intl => [
         accelerator: `${ctrlKey}+=`,
         click() {
           const activeService = getActiveWebview();
-          activeService.getZoomLevel((level) => {
-            // level 9 =~ +300% and setZoomLevel wouldnt zoom in further
-            if (level < 9) activeService.setZoomLevel(level + 1);
-          });
+          const level = activeService.getZoomLevel();
+
+          // level 9 =~ +300% and setZoomLevel wouldnt zoom in further
+          if (level < 9) activeService.setZoomLevel(level + 1);
         },
       },
       {
@@ -526,10 +526,10 @@ const _titleBarTemplateFactory = intl => [
         accelerator: `${ctrlKey}+-`,
         click() {
           const activeService = getActiveWebview();
-          activeService.getZoomLevel((level) => {
-            // level -9 =~ -50% and setZoomLevel wouldnt zoom out further
-            if (level > -9) activeService.setZoomLevel(level - 1);
-          });
+          const level = activeService.getZoomLevel();
+
+          // level -9 =~ -50% and setZoomLevel wouldnt zoom out further
+          if (level > -9) activeService.setZoomLevel(level - 1);
         },
       },
       {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
While Electron <6 [used a callback to get the current zoom level](https://github.com/electron/electron/blob/4-1-x/docs/api/webview-tag.md#webviewgetzoomlevelcallback), Electron 6 will [directly return the zoom level without a callback](https://electronjs.org/docs/api/webview-tag#webviewgetzoomlevel). This results in service zoom not working in Franz 5.4.X.

Related:
#1677 
#1673 


### Description
<!--- Describe your changes in detail -->
This PR will update `src/lib/Menu.js` to use the new syntax for `webview.getZoomLevel()` to enable zooming services to work again.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Zooming services in and out

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
