### PR TITLE
Fix `plan` PropType in FeatureList

### DIFF
--- a/src/components/ui/FeatureList.js
+++ b/src/components/ui/FeatureList.js
@@ -72,7 +72,7 @@ export class FeatureList extends Component {
   static propTypes = {
     className: PropTypes.string,
     featureClassName: PropTypes.string,
-    plan: PropTypes.oneOf(PLANS),
+    plan: PropTypes.oneOf(Object.values(PLANS)),
   };
 
   static defaultProps = {


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
When starting Franz 5.4.0, it is throwing an error "Invalid argument supplied to oneOf".
![Screenshot](https://user-images.githubusercontent.com/10333196/67632586-95eadc00-f8a5-11e9-8693-a23b21fb6cc7.png)

Looking into this, the error originates in `src/components/ui/FeatureList.js`, where the PropType for `plan` is set to `config.PLANS`. This constant is an object, but `oneOf` is requiring it to be an array. As it looks like, `FeatureList` is supplied with one of the values of `PLANS` (e.g. "personal" or "pro").
This PR will change the PropType for `plan` to `Object.values(PLANS)`, which will remove the error.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Starting Franz before and after the fix was applied. Before the error was there, after the fix the error was gone but everything was still working

### Screenshots (if appropriate):
![Screenshot](https://user-images.githubusercontent.com/10333196/67632586-95eadc00-f8a5-11e9-8693-a23b21fb6cc7.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
