### PR TITLE
Environment variables for portability

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -79,6 +79,15 @@ export const FILE_SYSTEM_SETTINGS_TYPES = [
   'proxy',
 ];
 
+// Set app directory before loading user modules
+if (process.env.FRANZ_APPDATA_DIR != null) {
+  app.setPath('appData', process.env.FRANZ_APPDATA_DIR);
+  app.setPath('userData', path.join(app.getPath('appData')));
+} else if (process.platform === 'win32') {
+  app.setPath('appData', process.env.APPDATA);
+  app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
+}
+
 export const SETTINGS_PATH = path.join(app.getPath('userData'), 'config');
 
 // Replacing app.asar is not beautiful but unforunately necessary

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,14 @@ import path from 'path';
 import windowStateKeeper from 'electron-window-state';
 
 // Set app directory before loading user modules
+if (process.env.FRANZ_APPDATA_DIR != null) {
+  app.setPath('appData', process.env.FRANZ_APPDATA_DIR);
+  app.setPath('userData', path.join(app.getPath('appData')));
+} else if (process.platform === 'win32') {
+  app.setPath('appData', process.env.APPDATA);
+  app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
+}
+
 if (isDevMode) {
   app.setPath('userData', path.join(app.getPath('appData'), 'FranzDev'));
 }


### PR DESCRIPTION
### Description
This is an environment variables for Franz (FRANZ_APPDATA_DIR) that I already used in a hard-fork (Ferdi). Where it can change where the folder "Franz" is used/created.

### Motivation and Context
I want this feature to help me to create a better FranzPortable with PortableApps.com format. And for other people who maybe prefer something else of %AppData%.

### How Has This Been Tested?
I already tested with a fork but I will build Franz myself later and confirming is functionnallity.

**UPDATE**: From this [build](https://ci.appveyor.com/project/adlk/franz/builds/28489849); everything is working fine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
