### PR TITLE
Removed slack section from the readme as the signup process is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ $ npm run build
 ## How can I support the project?
 If you have found a bug that hasn't been reported yet or want to request a new feature, please open a new issue.
 
-## I need help?
-Join the Franz community on [Slack](http://slack.franz.im) and get in touch with us.
 
 ## Create your own plugins/recipes
 You can find all the Information at the [Plugins repository](https://github.com/meetfranz/plugins).


### PR DESCRIPTION
### Description
Seeing as how the invite process is broken (Token revoked error when trying to join the slack channel) I felt that it was not necessary to have in the readme until this is fixed. This has been broken for sometime now. 

### Motivation and Context
Cleaner readme - removes broken links. 

### How Has This Been Tested?
Testing is not needed - just a readme update 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] readme / documentation update 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly. -->
