### PR TITLE
use brew install --cask instead of brew cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Messaging app for WhatsApp, Slack, Telegram, HipChat, Hangouts and many many mor
 
 ### Or use homebrew (macOS only)
 
-`$ brew cask install franz`
+`$ brew install --cask franz`
 
 (Don't know homebrew? [brew.sh](https://brew.sh/))
 


### PR DESCRIPTION
Changed brew command because brew cask is now longer supported

$ brew cask install franz
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.

### Description
use brew install --cask instead of brew cask

### Motivation and Context
brew no longer supports brew cask command