### PR TITLE
fix brew install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Messaging app for WhatsApp, Slack, Telegram, HipChat, Hangouts and many many mor
 
 ### Or use homebrew (macOS only)
 
-`$ brew cask install franz`
+`$ brew install --cask franz`
 
 (Don't know homebrew? [brew.sh](https://brew.sh/))
 


### PR DESCRIPTION
Fix the `brew install` command to use the modern syntax, as `brew cask install` is no longer supported.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context

```
⇒  brew cask install franz
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

### How Has This Been Tested?
N/A

### Screenshots (if appropriate):
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
